### PR TITLE
feat: landing page redesign — fresh branch from main

### DIFF
--- a/src/components/ArchDiagramSection/index.js
+++ b/src/components/ArchDiagramSection/index.js
@@ -1,0 +1,387 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './styles.module.css';
+
+function ArrowDown() {
+  return (
+    <svg className={styles.arrowDown} width="16" height="48" viewBox="0 0 16 48" fill="none" aria-hidden="true">
+      <line x1="8" y1="0" x2="8" y2="40" stroke="#999999" strokeWidth="2"/>
+      <polyline points="3,32 8,44 13,32" fill="none" stroke="#999999" strokeWidth="2" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+function ArrowBi() {
+  return (
+    <svg className={styles.arrowBi} width="56" height="16" viewBox="0 0 56 16" fill="none" aria-hidden="true">
+      <line x1="2" y1="8" x2="54" y2="8" stroke="#999999" strokeWidth="2"/>
+      <polyline points="10,3 2,8 10,13" fill="none" stroke="#999999" strokeWidth="2" strokeLinejoin="round"/>
+      <polyline points="46,3 54,8 46,13" fill="none" stroke="#999999" strokeWidth="2" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+function DatabaseIcon() {
+  return (
+    <svg width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+      <ellipse cx="22" cy="11" rx="16" ry="6" stroke="#aaaaaa" strokeWidth="1.5"/>
+      <path d="M6 11v11c0 3.31 7.16 6 16 6s16-2.69 16-6V11" stroke="#aaaaaa" strokeWidth="1.5"/>
+      <path d="M6 22v11c0 3.31 7.16 6 16 6s16-2.69 16-6V22" stroke="#aaaaaa" strokeWidth="1.5"/>
+    </svg>
+  );
+}
+
+function StorageIcon() {
+  return (
+    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" aria-hidden="true">
+      <rect x="3" y="4" width="30" height="12" rx="2" stroke="#aaaaaa" strokeWidth="1.5"/>
+      <rect x="3" y="20" width="30" height="12" rx="2" stroke="#aaaaaa" strokeWidth="1.5"/>
+      <circle cx="29" cy="10" r="2" fill="#aaaaaa"/>
+      <circle cx="29" cy="26" r="2" fill="#aaaaaa"/>
+    </svg>
+  );
+}
+
+const features = [
+  {
+    label: 'HA',
+    description: 'Automatic High Availability',
+    icon: (
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+        <rect x="2" y="2" width="24" height="24" rx="3" stroke="currentColor" strokeWidth="1.4"/>
+        <path d="M8 14l4 4 8-8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'Failover',
+    description: 'Automatic Failover & Self-Healing',
+    icon: (
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+        <rect x="2" y="9" width="9" height="10" rx="2" stroke="currentColor" strokeWidth="1.4"/>
+        <rect x="17" y="9" width="9" height="10" rx="2" stroke="currentColor" strokeWidth="1.4"/>
+        <path d="M11 14h6M15 11.5l2.5 2.5-2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'Backups',
+    description: 'Continuous Backups',
+    icon: (
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+        <rect x="5" y="3" width="18" height="22" rx="2" stroke="currentColor" strokeWidth="1.4"/>
+        <rect x="9" y="7" width="10" height="14" rx="1" stroke="currentColor" strokeWidth="1.4"/>
+        <line x1="12" y1="11" x2="17" y2="11" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+        <line x1="12" y1="15" x2="17" y2="15" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'PITR',
+    description: 'Point-in-Time Recovery',
+    icon: (
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+        <line x1="3" y1="14" x2="25" y2="14" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+        <line x1="7" y1="9" x2="7" y2="19" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+        <line x1="13" y1="9" x2="13" y2="19" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+        <line x1="19" y1="9" x2="19" y2="19" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+        <circle cx="22" cy="14" r="2.5" fill="currentColor"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'Monitoring',
+    description: 'Built-in Metrics & Alerting',
+    icon: (
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+        <polyline points="3,20 9,13 14,17 19,9 25,9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+        <line x1="3" y1="24" x2="25" y2="24" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'Upgrades',
+    description: 'Zero-Downtime Upgrades',
+    icon: (
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+        <path d="M14 4v17M9 15l5-11 5 11" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+        <line x1="7" y1="24" x2="21" y2="24" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+];
+
+function ExpandIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M1 5V1h4M9 1h4v4M13 9v4H9M5 13H1V9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+/* ── Reusable diagram JSX ────────────────────────────────────────────── */
+function DiagramInner({ compact }) {
+  return (
+    <div className={`${styles.diagram} ${compact ? styles.diagramCompact : ''}`}>
+      <div className={styles.row}>
+        <div className={styles.box}>Applications</div>
+      </div>
+      <div className={styles.arrowRow}><ArrowDown /></div>
+      <div className={styles.row}>
+        <div className={styles.box}>
+          PgBouncer <span className={styles.muted}>(optional)</span>
+        </div>
+      </div>
+      <div className={styles.arrowRow}><ArrowDown /></div>
+      <div className={styles.row}>
+        <div className={`${styles.box} ${styles.controlPlane}`}>
+          <div className={styles.cpHeader}>
+            <img src="/img/navbar/logo-icon.svg" alt="" width={28} height={25} />
+            <span className={styles.cpTitle}>Autobase Control Plane</span>
+          </div>
+          <div className={styles.cpPills}>
+            <span>Provisioning</span>
+            <span className={styles.sep}>|</span>
+            <span>Orchestration</span>
+            <span className={styles.sep}>|</span>
+            <span>Automation</span>
+            <span className={styles.sep}>|</span>
+            <span>Monitoring</span>
+          </div>
+        </div>
+      </div>
+      <div className={styles.splitArrows}>
+        <ArrowDown /><ArrowDown /><ArrowDown />
+      </div>
+      <div className={styles.clustersRow}>
+        <div className={styles.clusterBox}><DatabaseIcon /><span>PostgreSQL<br />Cluster 1</span></div>
+        <ArrowBi />
+        <div className={styles.clusterBox}><DatabaseIcon /><span>PostgreSQL<br />Cluster 2</span></div>
+        <ArrowBi />
+        <div className={styles.clusterBox}><DatabaseIcon /><span>PostgreSQL<br />Cluster N</span></div>
+      </div>
+      <div className={styles.arrowRow}><ArrowDown /></div>
+      <div className={styles.row}>
+        <div className={styles.box}>
+          <div className={styles.storageRow}>
+            <StorageIcon />
+            <div>
+              <div className={styles.storageTitle}>Object Storage / Backup Storage</div>
+              <div className={styles.storageSub}>S3, MinIO, NFS, etc.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Pinch-zoom / drag-pan lightbox ──────────────────────────────────── */
+function DiagramLightbox({ onClose }) {
+  const canvasRef  = useRef(null);
+  const contentRef = useRef(null);
+  const stateRef   = useRef({ scale: 1, x: 0, y: 0 });
+  const touchRef   = useRef(null);
+  const [scale, setScale] = useState(1);
+
+  const applyTransform = (s, x, y) => {
+    stateRef.current = { scale: s, x, y };
+    if (contentRef.current) {
+      contentRef.current.style.transform = `translate(${x}px, ${y}px) scale(${s})`;
+    }
+  };
+
+  const zoomBy = (delta) => {
+    const { scale: s, x, y } = stateRef.current;
+    const next = Math.min(5, Math.max(0.4, s + delta));
+    applyTransform(next, x, y);
+    setScale(next);
+  };
+
+  const reset = () => {
+    applyTransform(1, 0, 0);
+    setScale(1);
+  };
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+
+    const onTouchStart = (e) => {
+      e.preventDefault();
+      if (e.touches.length === 2) {
+        touchRef.current = {
+          type: 'pinch',
+          dist: Math.hypot(
+            e.touches[0].clientX - e.touches[1].clientX,
+            e.touches[0].clientY - e.touches[1].clientY,
+          ),
+          initScale: stateRef.current.scale,
+        };
+      } else {
+        touchRef.current = {
+          type: 'drag',
+          startX: e.touches[0].clientX,
+          startY: e.touches[0].clientY,
+          initX: stateRef.current.x,
+          initY: stateRef.current.y,
+        };
+      }
+    };
+
+    const onTouchMove = (e) => {
+      e.preventDefault();
+      const t = touchRef.current;
+      if (!t) return;
+      const { scale: s, x, y } = stateRef.current;
+
+      if (e.touches.length === 2 && t.type === 'pinch') {
+        const dist = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY,
+        );
+        const next = Math.min(5, Math.max(0.4, t.initScale * (dist / t.dist)));
+        applyTransform(next, x, y);
+      } else if (e.touches.length === 1 && t.type === 'drag') {
+        applyTransform(s,
+          t.initX + (e.touches[0].clientX - t.startX),
+          t.initY + (e.touches[0].clientY - t.startY),
+        );
+      }
+    };
+
+    const onTouchEnd = () => {
+      touchRef.current = null;
+      setScale(stateRef.current.scale);
+    };
+
+    el.addEventListener('touchstart',  onTouchStart, { passive: false });
+    el.addEventListener('touchmove',   onTouchMove,  { passive: false });
+    el.addEventListener('touchend',    onTouchEnd);
+    return () => {
+      el.removeEventListener('touchstart',  onTouchStart);
+      el.removeEventListener('touchmove',   onTouchMove);
+      el.removeEventListener('touchend',    onTouchEnd);
+    };
+  }, []);
+
+  /* Mouse drag support for desktop */
+  const mouseRef = useRef(null);
+  const onMouseDown = (e) => {
+    mouseRef.current = { startX: e.clientX, startY: e.clientY, initX: stateRef.current.x, initY: stateRef.current.y };
+  };
+  const onMouseMove = (e) => {
+    if (!mouseRef.current) return;
+    const m = mouseRef.current;
+    applyTransform(stateRef.current.scale,
+      m.initX + (e.clientX - m.startX),
+      m.initY + (e.clientY - m.startY),
+    );
+  };
+  const onMouseUp = () => {
+    mouseRef.current = null;
+    setScale(stateRef.current.scale);
+  };
+
+  /* Wheel zoom */
+  useEffect(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+    const onWheel = (e) => {
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -0.1 : 0.1;
+      const { scale: s, x, y } = stateRef.current;
+      const next = Math.min(5, Math.max(0.4, s + delta));
+      applyTransform(next, x, y);
+      setScale(next);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, []);
+
+  return createPortal(
+    <div className={styles.lbOverlay}>
+      <button className={styles.lbClose} onClick={onClose} aria-label="Close">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+        </svg>
+      </button>
+
+      <div
+        ref={canvasRef}
+        className={styles.lbCanvas}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseUp}
+        onDoubleClick={reset}
+      >
+        <div ref={contentRef} className={styles.lbContent}>
+          <DiagramInner />
+        </div>
+      </div>
+
+      <div className={styles.lbControls}>
+        <button className={styles.lbBtn} onClick={() => zoomBy(0.25)} aria-label="Zoom in">+</button>
+        <span className={styles.lbScale}>{Math.round(scale * 100)}%</span>
+        <button className={styles.lbBtn} onClick={() => zoomBy(-0.25)} aria-label="Zoom out">−</button>
+        <button className={styles.lbBtn} onClick={reset} aria-label="Reset zoom">↺</button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default function ArchDiagramSection() {
+  const [lbOpen,   setLbOpen]   = useState(false);
+  const [mounted,  setMounted]  = useState(false);
+
+  useEffect(() => { setMounted(true); }, []);
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+
+        {/* ── Architecture Diagram ── */}
+        <div className={styles.diagramWrapper}>
+          <DiagramInner />
+          <button
+            className={styles.expandBtn}
+            onClick={() => setLbOpen(true)}
+            aria-label="Expand diagram"
+          >
+            <ExpandIcon />
+            <span>Expand</span>
+          </button>
+        </div>
+
+        {mounted && lbOpen && <DiagramLightbox onClose={() => setLbOpen(false)} />}
+
+        {/* ── Divider ── */}
+        <hr className={styles.divider} />
+
+        {/* ── Features Grid ── */}
+        <div className={styles.featuresGrid}>
+          {features.map((f) => (
+            <div key={f.label} className={styles.featureCard}>
+              <div className={styles.featureIcon}>{f.icon}</div>
+              <div className={styles.featureLabel}>{f.label}</div>
+              <div className={styles.featureDesc}>{f.description}</div>
+            </div>
+          ))}
+        </div>
+
+      </div>
+    </section>
+  );
+}

--- a/src/components/ArchDiagramSection/styles.module.css
+++ b/src/components/ArchDiagramSection/styles.module.css
@@ -1,0 +1,384 @@
+/* ─── Section — full viewport width ──────────────────────────────── */
+.section {
+  width: 100vw;
+  min-height: 100vh;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  left: 50%;
+  margin-left: -50vw;
+}
+
+.inner {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ─── Diagram wrapper (for expand button) ─────────────────────────── */
+.diagramWrapper {
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ─── Expand button ───────────────────────────────────────────────── */
+.expandBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 20px;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  font-family: var(--font-base);
+  font-size: 13px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.expandBtn:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+
+/* ─── Diagram ─────────────────────────────────────────────────────── */
+.diagram {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ─── Row ─────────────────────────────────────────────────────────── */
+.row {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+/* ─── Box ─────────────────────────────────────────────────────────── */
+.box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 0;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 20px;
+  font-weight: 400;
+  color: var(--color-text);
+  background: var(--color-surface);
+  width: 80%;
+}
+
+.muted {
+  color: var(--color-text-muted);
+  margin-left: 8px;
+}
+
+/* ─── Arrow down ──────────────────────────────────────────────────── */
+.arrowRow {
+  display: flex;
+  justify-content: center;
+  height: 48px;
+  align-items: center;
+}
+
+.arrowDown { display: block; }
+
+/* ─── Control Plane ───────────────────────────────────────────────── */
+.controlPlane {
+  flex-direction: column;
+  gap: 14px;
+  padding: 32px 0;
+  border-color: var(--color-primary);
+  border-width: 2px;
+  width: 80%;
+}
+
+.cpHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.cpTitle {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.cpPills {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 16px;
+  color: var(--color-text-muted);
+}
+
+.sep { color: var(--color-border); }
+
+/* ─── Split arrows ────────────────────────────────────────────────── */
+.splitArrows {
+  width: 80%;
+  display: flex;
+  justify-content: space-around;
+  height: 48px;
+}
+
+/* ─── Clusters ────────────────────────────────────────────────────── */
+.clustersRow {
+  display: flex;
+  align-items: center;
+  width: 80%;
+}
+
+.clusterBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 32px 0;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 16px;
+  color: var(--color-text);
+  text-align: center;
+  line-height: 1.5;
+  flex: 1;
+  background: var(--color-surface);
+}
+
+.arrowBi { display: block; flex-shrink: 0; }
+
+/* ─── Storage ─────────────────────────────────────────────────────── */
+.storageRow {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  text-align: left;
+}
+
+.storageTitle {
+  font-size: 20px;
+  color: var(--color-text);
+}
+
+.storageSub {
+  font-size: 15px;
+  color: var(--color-text-muted);
+  margin-top: 6px;
+}
+
+/* ─── Divider ─────────────────────────────────────────────────────── */
+.divider {
+  width: 80%;
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 48px auto;
+}
+
+/* ─── Features Grid ───────────────────────────────────────────────── */
+.featuresGrid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.featureCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 32px 24px;
+  border-right: 2px solid var(--color-border);
+  transition: background 0.2s ease;
+}
+
+.featureCard:last-child { border-right: none; }
+.featureCard:hover { background: var(--color-surface); }
+
+.featureIcon { color: var(--color-text); }
+
+.featureLabel {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  color: var(--color-text);
+}
+
+.featureDesc {
+  font-size: 16px;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+/* ─── Lightbox overlay ────────────────────────────────────────────── */
+.lbOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99998;
+  background: rgba(0, 0, 0, 0.88);
+  display: flex;
+  flex-direction: column;
+  animation: lbFadeIn 0.2s ease forwards;
+}
+
+@keyframes lbFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.lbCanvas {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.lbCanvas:active { cursor: grabbing; }
+
+.lbContent {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 48px 60px;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+/* ─── Lightbox controls ───────────────────────────────────────────── */
+.lbControls {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(10, 10, 10, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 100px;
+  padding: 6px 12px;
+  backdrop-filter: blur(12px);
+  z-index: 1;
+}
+
+.lbBtn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: #ccc;
+  font-size: 20px;
+  font-weight: 300;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.lbBtn:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.lbScale {
+  color: #888;
+  font-family: monospace;
+  font-size: 13px;
+  min-width: 46px;
+  text-align: center;
+}
+
+.lbClose {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.5);
+  color: #ccc;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(8px);
+  transition: color 0.15s ease, background 0.15s ease;
+  z-index: 2;
+}
+
+.lbClose:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .inner { padding: 0 48px; }
+  .box, .controlPlane, .splitArrows, .clustersRow { width: 90%; }
+  .featuresGrid { grid-template-columns: repeat(3, 1fr); }
+  .featureCard:nth-child(3) { border-right: none; }
+  .featureCard:nth-child(n+4) { border-top: 2px solid var(--color-border); }
+}
+
+@media (max-width: 768px) {
+  .inner { padding: 40px 24px; }
+  .section { min-height: auto; }
+  .box, .controlPlane, .splitArrows, .clustersRow { width: 100%; }
+  .box { font-size: 15px; padding: 20px 12px; }
+  .cpTitle { font-size: 18px; }
+  .cpPills { font-size: 13px; gap: 8px; }
+  .clusterBox { padding: 20px 8px; font-size: 13px; gap: 8px; }
+  .storageTitle { font-size: 15px; }
+  .storageSub { font-size: 13px; }
+  .featuresGrid { grid-template-columns: repeat(2, 1fr); }
+  .featureCard:nth-child(2n) { border-right: none; }
+  .featureCard:nth-child(3),
+  .featureCard:nth-child(4),
+  .featureCard:nth-child(5),
+  .featureCard:nth-child(6) { border-top: 2px solid var(--color-border); }
+  .featureCard:nth-child(3) { border-right: 1px solid var(--color-border); }
+  .featureCard:nth-child(5) { border-right: 1px solid var(--color-border); }
+  .featureDesc { font-size: 13px; }
+  .divider { margin: 32px auto; }
+  .lbContent { padding: 32px 24px; }
+}
+
+@media (max-width: 480px) {
+  .inner { padding: 32px 16px; }
+  .featuresGrid { grid-template-columns: 1fr; }
+  .featureCard { border-right: none; border-bottom: 2px solid var(--color-border); }
+  .featureCard:last-child { border-bottom: none; }
+  .featureCard:nth-child(n) { border-top: none; border-right: none; }
+  .clustersRow { flex-direction: column; gap: 0; }
+  .arrowBi { transform: rotate(90deg); }
+  .splitArrows { display: none; }
+  .clusterBox { width: 100%; border-radius: 0; }
+  .clusterBox:first-child { border-radius: 6px 6px 0 0; }
+  .clusterBox:last-child  { border-radius: 0 0 6px 6px; }
+}

--- a/src/components/CLISection/index.js
+++ b/src/components/CLISection/index.js
@@ -1,0 +1,486 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './styles.module.css';
+
+/* ── Getting-started workflow (inline terminal) ─────────────────────── */
+const SEQUENCES = [
+  {
+    command: '$ curl -fsSL https://autobase.tech/platform.yml \\\n    --output ./docker-compose.platform.yml',
+    result:  '✓ Downloaded',
+    detail:  '  ./docker-compose.platform.yml',
+  },
+  {
+    command: '$ docker compose \\\n    -f docker-compose.platform.yml up -d',
+    result:  '✓ Autobase Console started',
+    detail:  '  http://your-server-address',
+  },
+  {
+    command: '$ curl -fsSL https://autobase.tech/platform.ssl.yml \\\n    --output ./docker-compose.platform.ssl.yml',
+    result:  '✓ Downloaded',
+    detail:  '  ./docker-compose.platform.ssl.yml',
+  },
+  {
+    command: '$ docker compose \\\n    -f docker-compose.platform.ssl.yml up -d',
+    result:  '✓ Autobase Console started (SSL)',
+    detail:  '  https://autobase.example.com',
+  },
+];
+
+/* ── Getting-started workflow (fullscreen terminal — sequential) ────── */
+const FS_SEQUENCES = [
+  {
+    command: '$ curl -fsSL https://autobase.tech/platform.yml \\\n    --output ./docker-compose.platform.yml',
+    result:  '✓ Downloaded',
+    detail:  '  ./docker-compose.platform.yml',
+  },
+  {
+    command: '$ echo "AUTH_TOKEN=secret-token" > .env',
+    result:  '✓ Environment configured',
+    detail:  '  .env',
+  },
+  {
+    command: '$ docker compose \\\n    -f docker-compose.platform.yml up -d',
+    result:  '✓ Autobase Console started',
+    detail:  '  http://your-server-address',
+  },
+  {
+    command: '$ curl -fsSL https://autobase.tech/platform.ssl.yml \\\n    --output ./docker-compose.platform.ssl.yml',
+    result:  '✓ Downloaded',
+    detail:  '  ./docker-compose.platform.ssl.yml',
+  },
+  {
+    command: '$ echo "DOMAIN=autobase.example.com\nACME_EMAIL=admin@example.com\nAUTH_TOKEN=secret-token" > .env',
+    result:  '✓ SSL environment configured',
+    detail:  '  .env',
+  },
+  {
+    command: '$ docker compose \\\n    -f docker-compose.platform.ssl.yml up -d',
+    result:  '✓ Autobase Console started (SSL)',
+    detail:  '  https://autobase.example.com',
+  },
+  {
+    command: '$ autobase upgrade \\\n    --cluster production \\\n    --from 15 --to 16',
+    result:  '✓ Upgrade complete — zero downtime',
+    detail:  '  primary: 16.3  replicas: 16.3',
+  },
+  {
+    command: '=# CHECKPOINT;',
+    result:  'CHECKPOINT',
+    detail:  '  wal_lsn: 0/3B00000  duration: 0.21s',
+  },
+];
+
+const CLEAR_CMD  = '\n$ \\! clear';
+const CHAR_SPEED = 28;
+const FS_SPEED   = 12;    // faster for fullscreen
+const CLS_SPEED  = 90;
+const HOLD_MS    = 2600;
+const FLASH_MS   = 420;
+const FS_HOLD_MS = 1800;  // shorter hold in fullscreen before next command
+
+
+/* ── Code-rain canvas for the overlay background ──────────────────── */
+const RAIN_CHARS = (
+  '0123456789ABCDEFabcdef' +
+  'SELECTFROMWHEREINSERTUPDATECREATEINDEXREPLICACLUSTER' +
+  'WALPSQLNODESHARDLSNPGBASEAUTOBASE\\$=>_{}[]|;:,.'
+).split('').filter((c, i, a) => a.indexOf(c) === i);
+
+function MatrixCanvas() {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+
+    const FONT_SIZE = 14;
+    const LINE_H    = 20;
+
+    let width, height, cols, drops, speeds, brightChance, frames;
+
+    function init() {
+      width  = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width  = width;
+      canvas.height = height;
+      cols   = Math.floor(width / FONT_SIZE);
+      drops  = Array.from({ length: cols }, () => Math.random() * -(height / LINE_H));
+      speeds = Array.from({ length: cols }, () => 0.18 + Math.random() * 0.38);
+      brightChance = Array.from({ length: cols }, () => Math.random());
+      frames = 0;
+      ctx.fillStyle = '#040404';
+      ctx.fillRect(0, 0, width, height);
+    }
+
+    init();
+    window.addEventListener('resize', init);
+
+    let raf;
+    function draw() {
+      frames++;
+
+      // Slowly fade existing pixels (trail effect)
+      ctx.fillStyle = 'rgba(4, 4, 4, 0.055)';
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.font = `${FONT_SIZE}px "Courier New", monospace`;
+
+      for (let i = 0; i < cols; i++) {
+        const y = Math.floor(drops[i]) * LINE_H;
+        if (y < -LINE_H || y > height + LINE_H) {
+          drops[i] += speeds[i];
+          continue;
+        }
+
+        const char = RAIN_CHARS[Math.floor(Math.random() * RAIN_CHARS.length)];
+        const roll = Math.random();
+
+        if (roll < 0.006) {
+          // Orange spark — very rare
+          ctx.fillStyle = `rgba(255, 100, 30, ${0.55 + Math.random() * 0.3})`;
+        } else if (roll < 0.025 && brightChance[i] > 0.7) {
+          // Bright green-white head
+          ctx.fillStyle = `rgba(200, 230, 200, ${0.18 + Math.random() * 0.12})`;
+        } else if (roll < 0.10) {
+          // Mid green
+          ctx.fillStyle = `rgba(50, 130, 70, ${0.06 + Math.random() * 0.05})`;
+        } else {
+          // Dim: almost invisible
+          ctx.fillStyle = `rgba(20, 55, 30, ${0.025 + Math.random() * 0.025})`;
+        }
+
+        ctx.fillText(char, i * FONT_SIZE, y);
+
+        drops[i] += speeds[i];
+
+        // Reset column when it exits the bottom
+        if (y > height && Math.random() > 0.975) {
+          drops[i] = Math.random() * -(height / LINE_H * 0.5);
+          speeds[i] = 0.18 + Math.random() * 0.38;
+          brightChance[i] = Math.random();
+        }
+      }
+
+      raf = requestAnimationFrame(draw);
+    }
+
+    draw();
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', init);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={ref}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        zIndex: 0,
+      }}
+    />
+  );
+}
+
+function ExpandIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M1 5V1h4M9 1h4v4M13 9v4H9M5 13H1V9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+function CollapseIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M5 1v4H1M13 5H9V1M9 13v-4h4M1 9h4v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+/* ── Inline terminal body (cycles SEQUENCES) ──────────────────────── */
+function InlineBody({ typed, clsTyped, phase, seq }) {
+  const showResult = phase === 'showing' || phase === 'typing_cls' || phase === 'flash';
+  const showCls    = phase === 'typing_cls' || phase === 'flash';
+  const isFlashing = phase === 'flash';
+  const displayText = typed.startsWith('$ ') ? typed.slice(2) : typed;
+
+  return (
+    <pre className={`${styles.terminalCode} ${isFlashing ? styles.terminalFlash : ''}`}>
+      <span className={styles.prompt}>$</span>
+      {displayText}
+      {phase === 'typing' && <span className={styles.caret}>_</span>}
+      {showResult && (
+        <>
+          {'\n\n'}
+          <span className={styles.success}>{seq.result}</span>
+          {'\n'}
+          <span className={styles.dimmed}>{seq.detail}</span>
+        </>
+      )}
+      {showCls && (
+        <>
+          {'\n'}
+          <span className={styles.dimmed}>{clsTyped}</span>
+          {phase === 'typing_cls' && clsTyped.length < CLEAR_CMD.length && (
+            <span className={styles.caret}>_</span>
+          )}
+        </>
+      )}
+    </pre>
+  );
+}
+
+/* ── Fullscreen terminal body (independent random cycling) ────────── */
+function FullscreenBody({ fsSeq, fsTyped, fsPhase }) {
+  const showResult = fsPhase === 'showing' || fsPhase === 'clearing';
+  const isClearing = fsPhase === 'clearing';
+
+  return (
+    <div className={styles.fsLayout}>
+      {/* Scrolling terminal area */}
+      <pre className={`${styles.terminalCodeFull} ${isClearing ? styles.terminalFlash : ''}`}>
+        {fsSeq.command.startsWith('=# ') ? (
+          <>
+            <span className={styles.promptPg}>=# </span>
+            {fsSeq.command.slice(3)}
+          </>
+        ) : (
+          <>
+            <span className={styles.prompt}>$</span>
+            {fsSeq.command.startsWith('$ ') ? fsSeq.command.slice(2) : fsSeq.command}
+          </>
+        )}
+        {fsPhase === 'typing' && <span className={styles.caret}>_</span>}
+        {showResult && (
+          <>
+            {'\n\n'}
+            <span className={styles.success}>{fsSeq.result}</span>
+            {'\n'}
+            <span className={styles.dimmed}>{fsSeq.detail}</span>
+          </>
+        )}
+      </pre>
+
+      {/* CTA menu — fixed below terminal, always visible */}
+      <div className={styles.ctaMenu}>
+        <div className={styles.menuDivider} />
+        <a
+          href="https://github.com/autobase-tech/autobase"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.menuItem}
+        >
+          <span className={styles.menuPrompt}>&gt;</span>
+          <span className={styles.menuTitle}> Download Community Edition</span>
+          <span className={styles.menuSub}>Open Source · Self-Hosted · Free</span>
+        </a>
+        <a
+          href="https://demo.autobase.tech"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.menuItem}
+        >
+          <span className={styles.menuPrompt}>&gt;</span>
+          <span className={styles.menuTitle}> Book Demo</span>
+          <span className={styles.menuSub}>Talk to our engineers</span>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default function CLISection() {
+  /* ── Inline cycling state ── */
+  const [seqIdx,   setSeqIdx]   = useState(0);
+  const [typed,    setTyped]    = useState('');
+  const [clsTyped, setClsTyped] = useState('');
+  const [phase,    setPhase]    = useState('typing');
+  const timer = useRef(null);
+
+  /* ── Fullscreen state ── */
+  const [fullscreen, setFullscreen] = useState(false);
+  const [fsClosing,  setFsClosing]  = useState(false);
+  const [fsIdx,      setFsIdx]      = useState(0);
+  const [fsTyped,    setFsTyped]    = useState('');
+  const [fsPhase,    setFsPhase]    = useState('idle'); // idle | typing | showing | clearing
+  const fsTimer = useRef(null);
+
+  const seq    = SEQUENCES[seqIdx];
+  const fsSeq  = FS_SEQUENCES[fsIdx];
+
+  /* ── Inline typewriter ── */
+  useEffect(() => {
+    if (phase !== 'typing') return;
+    clearTimeout(timer.current);
+    const cmd = seq.command;
+    if (typed.length < cmd.length) {
+      timer.current = setTimeout(() => setTyped(cmd.slice(0, typed.length + 1)), CHAR_SPEED);
+    } else {
+      timer.current = setTimeout(() => setPhase('showing'), 300);
+    }
+    return () => clearTimeout(timer.current);
+  }, [phase, typed, seq.command]);
+
+  useEffect(() => {
+    if (phase !== 'showing') return;
+    timer.current = setTimeout(() => { setClsTyped(''); setPhase('typing_cls'); }, HOLD_MS);
+    return () => clearTimeout(timer.current);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== 'typing_cls') return;
+    clearTimeout(timer.current);
+    if (clsTyped.length < CLEAR_CMD.length) {
+      timer.current = setTimeout(() => setClsTyped(CLEAR_CMD.slice(0, clsTyped.length + 1)), CLS_SPEED);
+    } else {
+      timer.current = setTimeout(() => setPhase('flash'), 180);
+    }
+    return () => clearTimeout(timer.current);
+  }, [phase, clsTyped]);
+
+  useEffect(() => {
+    if (phase !== 'flash') return;
+    timer.current = setTimeout(() => {
+      setTyped(''); setClsTyped('');
+      setSeqIdx(i => (i + 1) % SEQUENCES.length);
+      setPhase('typing');
+    }, FLASH_MS);
+    return () => clearTimeout(timer.current);
+  }, [phase]);
+
+  /* ── Fullscreen: start fresh on open ── */
+  useEffect(() => {
+    if (fullscreen) {
+      setFsIdx(0);
+      setFsTyped('');
+      setFsPhase('typing');
+    } else {
+      clearTimeout(fsTimer.current);
+      setFsPhase('idle');
+    }
+  }, [fullscreen]);
+
+  /* ── Fullscreen typewriter ── */
+  useEffect(() => {
+    if (fsPhase !== 'typing') return;
+    clearTimeout(fsTimer.current);
+    const target = fsSeq.command;
+    if (fsTyped.length < target.length) {
+      fsTimer.current = setTimeout(() => setFsTyped(target.slice(0, fsTyped.length + 1)), FS_SPEED);
+    } else {
+      fsTimer.current = setTimeout(() => setFsPhase('showing'), 240);
+    }
+    return () => clearTimeout(fsTimer.current);
+  }, [fsPhase, fsTyped, fsSeq.command]);
+
+  /* ── Fullscreen hold → clear → next ── */
+  useEffect(() => {
+    if (fsPhase !== 'showing') return;
+    fsTimer.current = setTimeout(() => setFsPhase('clearing'), FS_HOLD_MS);
+    return () => clearTimeout(fsTimer.current);
+  }, [fsPhase]);
+
+  useEffect(() => {
+    if (fsPhase !== 'clearing') return;
+    fsTimer.current = setTimeout(() => {
+      setFsTyped('');
+      setFsIdx(i => (i + 1) % FS_SEQUENCES.length);
+      setFsPhase('typing');
+    }, FLASH_MS);
+    return () => clearTimeout(fsTimer.current);
+  }, [fsPhase]);
+
+  /* ── Close with exit animation ── */
+  const closeFullscreen = () => {
+    setFsClosing(true);
+    setTimeout(() => {
+      setFsClosing(false);
+      setFullscreen(false);
+    }, 280);
+  };
+
+  /* ── Escape key ── */
+  useEffect(() => {
+    if (!fullscreen) return;
+    const onKey = (e) => { if (e.key === 'Escape') closeFullscreen(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [fullscreen]);
+
+  const bar = (isFullscreen) => (
+    <div className={styles.terminalBar}>
+      <span className={styles.dot} /><span className={styles.dot} /><span className={styles.dot} />
+      <button
+        className={styles.expandBtn}
+        onClick={() => isFullscreen ? closeFullscreen() : setFullscreen(true)}
+        aria-label="Toggle fullscreen"
+      >
+        {isFullscreen ? <CollapseIcon /> : <ExpandIcon />}
+      </button>
+    </div>
+  );
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.layout}>
+
+          <div className={styles.terminal}>
+            {bar(false)}
+            <InlineBody typed={typed} clsTyped={clsTyped} phase={phase} seq={seq} />
+          </div>
+
+          <div className={styles.ctas}>
+            <a
+              href="https://github.com/autobase-tech/autobase"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.ctaPrimary}
+            >
+              <span className={styles.ctaArrow}>&gt;</span>
+              <span>
+                <div className={styles.ctaTitle}>DOWNLOAD COMMUNITY EDITION</div>
+                <div className={styles.ctaSubtitle}>Open Source · Self-Hosted · Free</div>
+              </span>
+            </a>
+            <a
+              href="https://demo.autobase.tech"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.ctaSecondary}
+            >
+              <span className={styles.ctaArrow}>&gt;</span>
+              <span>
+                <div className={styles.ctaTitle}>BOOK DEMO</div>
+                <div className={styles.ctaSubtitle}>Talk to our engineers</div>
+              </span>
+            </a>
+          </div>
+
+        </div>
+      </div>
+
+      {fullscreen && typeof document !== 'undefined' && createPortal(
+        <div
+          className={`${styles.overlay} ${fsClosing ? styles.overlayClosing : ''}`}
+          onClick={closeFullscreen}
+        >
+          <MatrixCanvas />
+          <div
+            className={`${styles.overlayTerminal} ${fsClosing ? styles.overlayTerminalClosing : ''}`}
+            onClick={e => e.stopPropagation()}
+          >
+            {bar(true)}
+            <FullscreenBody fsSeq={fsSeq} fsTyped={fsTyped} fsPhase={fsPhase} />
+          </div>
+        </div>,
+        document.body
+      )}
+    </section>
+  );
+}

--- a/src/components/CLISection/styles.module.css
+++ b/src/components/CLISection/styles.module.css
@@ -1,0 +1,421 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.section {
+  background: var(--color-bg);
+  padding: var(--section-pt) 0 var(--section-pb);
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 80px;
+}
+
+/* ─── Two-column layout ───────────────────────────────────────────── */
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  align-items: center;
+}
+
+/* ─── Terminal (inline) ───────────────────────────────────────────── */
+.terminal {
+  background: #0d0d0d;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
+}
+
+.terminalBar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 18px;
+  background: #1a1a1a;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #3a3a3a;
+}
+
+.expandBtn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #555;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.expandBtn:hover {
+  color: #bbb;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+/* ─── Terminal code block ─────────────────────────────────────────── */
+.terminalCode {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 14px;
+  line-height: 1.7;
+  color: #c8c8c8;
+  padding: 24px 28px;
+  margin: 0;
+  white-space: pre;
+  overflow-x: auto;
+  background: transparent;
+  border: none;
+  min-height: 220px;
+}
+
+.terminalCodeFull {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 15px;
+  line-height: 1.75;
+  color: #c8c8c8;
+  padding: 36px 44px 28px;
+  margin: 0;
+  white-space: pre;
+  overflow-x: auto;
+  background: transparent;
+  border: none;
+  min-height: 160px;
+}
+
+.promptPg {
+  color: #569cd6;
+  font-weight: bold;
+}
+
+/* CRT phosphor flash */
+.terminalFlash {
+  animation: crtClear 0.42s ease-in forwards;
+}
+
+@keyframes crtClear {
+  0%   { opacity: 1;    filter: brightness(1)   blur(0px);  }
+  25%  { opacity: 1;    filter: brightness(3.5) blur(1px);  }
+  55%  { opacity: 0.15; filter: brightness(0.4) blur(2px);  }
+  100% { opacity: 0;    filter: brightness(0)   blur(0px);  }
+}
+
+.prompt {
+  color: var(--color-primary);
+  font-weight: bold;
+}
+
+.caret {
+  display: inline-block;
+  color: #c8c8c8;
+  animation: caretBlink 1s step-end infinite;
+  user-select: none;
+}
+
+@keyframes caretBlink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.success {
+  color: #4caf50;
+  font-weight: bold;
+}
+
+.dimmed {
+  color: #666666;
+}
+
+/* ─── Fullscreen layout ───────────────────────────────────────────── */
+.fsLayout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* ─── Fullscreen CTA menu ─────────────────────────────────────────── */
+.ctaMenu {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 44px 36px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.menuDivider {
+  height: 1px;
+  background: #1e1e1e;
+  margin-bottom: 20px;
+}
+
+.menuItem {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  grid-template-rows: auto auto;
+  gap: 2px 10px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s ease;
+  margin-bottom: 4px;
+}
+
+.menuItem:hover {
+  background: rgba(255, 255, 255, 0.04);
+  text-decoration: none;
+}
+
+.menuItem:hover .menuPrompt { color: #ff7043; }
+.menuItem:hover .menuTitle  { color: #ffffff;  }
+.menuItem:hover .menuSub    { color: #888888;  }
+
+.menuPrompt {
+  grid-column: 1;
+  grid-row: 1 / 3;
+  align-self: center;
+  color: var(--color-primary);
+  font-weight: bold;
+  font-size: 17px;
+  transition: color 0.15s ease;
+}
+
+.menuTitle {
+  grid-column: 2;
+  grid-row: 1;
+  color: #d0d0d0;
+  font-weight: bold;
+  letter-spacing: 0.3px;
+  transition: color 0.15s ease;
+}
+
+.menuSub {
+  grid-column: 2;
+  grid-row: 2;
+  color: #444;
+  font-size: 13px;
+  transition: color 0.15s ease;
+}
+
+/* ─── CTAs column (original) ──────────────────────────────────────── */
+.ctas {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ctaPrimary,
+.ctaSecondary {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 24px 28px;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.ctaPrimary:hover,
+.ctaSecondary:hover {
+  opacity: 0.85;
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
+.ctaPrimary {
+  border: 1.5px solid var(--color-primary);
+  background: transparent;
+}
+
+.ctaSecondary {
+  border: 1.5px solid var(--color-border);
+  outline: 1.5px solid transparent;
+  outline-offset: 0px;
+  background: transparent;
+  transform-style: preserve-3d;
+  transform-origin: center top;
+  transition: border-color 0.18s ease, outline-color 0.18s ease,
+              background 0.18s ease,
+              transform 0.18s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              box-shadow 0.18s ease;
+}
+
+.ctaSecondary:hover {
+  border-color: var(--color-primary);
+  outline-color: var(--color-primary);
+  background: var(--color-surface);
+  opacity: 1;
+  transform: perspective(600px) rotateX(-7deg) translateY(4px) scaleY(0.97);
+  box-shadow: 0 4px 0 rgba(0,0,0,0.07), inset 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.ctaArrow {
+  font-family: monospace;
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.ctaTitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-bold);
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.ctaSubtitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  margin-top: 4px;
+}
+
+/* ─── Fullscreen overlay ──────────────────────────────────────────── */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 99999;
+  /* Canvas handles darkening; keep bg as pure black base */
+  background: #040404;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: overlayIn 0.25s ease forwards;
+}
+
+.overlayClosing {
+  animation: overlayOut 0.28s ease forwards;
+}
+
+@keyframes overlayIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes overlayOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.overlayTerminal {
+  position: relative;
+  z-index: 1;
+  background: rgba(10, 10, 10, 0.92);
+  backdrop-filter: blur(2px);
+  border-radius: 12px;
+  box-shadow:
+    0 0 0 1px #2a2a2a,
+    0 40px 100px rgba(0, 0, 0, 0.9),
+    0 0 120px rgba(255, 87, 34, 0.06),
+    0 0 40px rgba(30, 100, 50, 0.08);
+  width: min(860px, 90vw);
+  height: min(560px, 85vh);
+  overflow-y: auto;
+  animation: windowOpen 0.32s cubic-bezier(0.34, 1.46, 0.64, 1) forwards;
+  transform-origin: center center;
+}
+
+.overlayTerminalClosing {
+  animation: windowClose 0.22s cubic-bezier(0.55, 0, 1, 0.45) forwards;
+}
+
+@keyframes windowClose {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    filter: brightness(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.88) translateY(18px);
+    filter: brightness(0.4);
+  }
+}
+
+/* Scanline sweep on open */
+.overlayTerminal::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  height: 3px;
+  background: linear-gradient(to bottom,
+    transparent 0%,
+    rgba(150, 255, 180, 0.18) 50%,
+    transparent 100%
+  );
+  animation: scanline 0.7s ease-in 0.08s forwards;
+  pointer-events: none;
+  z-index: 1;
+}
+
+@keyframes scanline {
+  0%   { top: 0;    opacity: 0.7; }
+  85%  { top: 100%; opacity: 0.3; }
+  100% { top: 100%; opacity: 0;   }
+}
+
+@keyframes windowOpen {
+  from {
+    opacity: 0;
+    transform: scale(0.84) translateY(28px);
+    filter: brightness(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    filter: brightness(1);
+  }
+}
+
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; }
+  .layout { grid-template-columns: 1fr; }
+  .ctas { flex-direction: row; flex-wrap: wrap; gap: 12px; }
+  .ctaPrimary, .ctaSecondary { flex: 1; min-width: 200px; padding: 20px 20px; }
+}
+
+@media (max-width: 600px) {
+  .inner { padding: 0 20px; }
+  .terminalCode { font-size: 12px; padding: 16px; min-height: 160px; }
+  .ctas { flex-direction: column; }
+  .ctaPrimary, .ctaSecondary { width: 100%; }
+}
+
+/* ─── Fullscreen overlay — mobile ─────────────────────────────────── */
+@media (max-width: 768px) {
+  .overlayTerminal {
+    width: 96vw;
+    height: 90vh;
+    border-radius: 8px;
+  }
+  .terminalCodeFull {
+    font-size: 12px;
+    padding: 24px 20px 16px;
+    min-height: 120px;
+  }
+  .ctaMenu {
+    padding: 0 20px 24px;
+    font-size: 13px;
+  }
+  .menuItem {
+    padding: 8px 8px;
+    grid-template-columns: 20px 1fr;
+  }
+  .menuPrompt { font-size: 15px; }
+}

--- a/src/components/ClickEffect/index.js
+++ b/src/components/ClickEffect/index.js
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef } from 'react';
+
+// Digits pool — mix of decimal + hex for a pg/terminal data feel
+const DIGITS = '0123456789ABCDEF01234567890123456789';
+
+// Weighted color pool — mostly dark, rare orange spark
+const COLORS = [
+  { color: '#111111', weight: 5 },
+  { color: '#555555', weight: 3 },
+  { color: '#999999', weight: 2 },
+  { color: '#ff5722', weight: 1 },
+];
+const TOTAL_WEIGHT = COLORS.reduce((s, c) => s + c.weight, 0);
+
+function pickColor() {
+  let r = Math.random() * TOTAL_WEIGHT;
+  for (const c of COLORS) {
+    r -= c.weight;
+    if (r <= 0) return c.color;
+  }
+  return COLORS[0].color;
+}
+
+function pickDigit() {
+  return DIGITS[Math.floor(Math.random() * DIGITS.length)];
+}
+
+export default function ClickEffect() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    let particles = [];
+    let raf;
+
+    function resize() {
+      canvas.width  = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+    resize();
+    window.addEventListener('resize', resize);
+
+    function spawn(x, y) {
+      const count = 8 + Math.floor(Math.random() * 7);
+      for (let i = 0; i < count; i++) {
+        const angle = Math.random() * Math.PI * 2;
+        const speed = 1.2 + Math.random() * 4;
+        const fontSize = 10 + Math.floor(Math.random() * 8); // 10–17px
+        particles.push({
+          x, y,
+          vx: Math.cos(angle) * speed,
+          vy: Math.sin(angle) * speed - 2,  // bias upward
+          alpha: 0.9 + Math.random() * 0.1,
+          decay: 0.025 + Math.random() * 0.025,
+          color: pickColor(),
+          digit: pickDigit(),
+          fontSize,
+          font: `${fontSize}px "Courier New", monospace`,
+        });
+      }
+    }
+
+    function animate() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      particles = particles.filter(p => p.alpha > 0);
+      for (const p of particles) {
+        p.x  += p.vx;
+        p.y  += p.vy;
+        p.vy += 0.18;   // gravity
+        p.vx *= 0.97;   // drag
+        p.alpha -= p.decay;
+
+        ctx.globalAlpha = Math.max(0, p.alpha);
+        ctx.fillStyle   = p.color;
+        ctx.font        = p.font;
+        ctx.fillText(p.digit, Math.round(p.x), Math.round(p.y));
+      }
+      ctx.globalAlpha = 1;
+      raf = requestAnimationFrame(animate);
+    }
+    animate();
+
+    function onClick(e) { spawn(e.clientX, e.clientY); }
+    document.addEventListener('click', onClick);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener('click', onClick);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        zIndex: 9999,
+      }}
+    />
+  );
+}

--- a/src/components/CloudProviders/styles.module.css
+++ b/src/components/CloudProviders/styles.module.css
@@ -1,35 +1,39 @@
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+/* ─── Section ────────────────────────────────────────────────────── */
+.section {
+  margin: 0 110px;
+  padding: var(--section-pt) 0 var(--section-pb);
+  min-height: 65vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
+@media (max-width: 1200px) { .section { margin: 0 80px; } }
+@media (max-width: 900px)  { .section { margin: 0 48px; } }
+@media (max-width: 768px)  { .section { margin: 0 24px; } }
+
+
 .heading {
-  font-size: 1.6rem;
-  font-weight: bold;
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
   margin-top: 40px;
   margin-bottom: 10px;
   text-align: center;
-  opacity: 0;
-  animation: fadeIn 0.3s ease-in-out;
-  animation-delay: 1s;
-  animation-fill-mode: forwards;
+  line-height: 1.15;
 }
 
 .cloudProvidersList {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 40px;
-  opacity: 0;
-  animation: fadeIn 0.3s ease-in-out;
-  animation-delay: 1s;
-  animation-fill-mode: forwards;
+  gap: 24px;
   margin-top: 40px;
 }
+
+.orange { color: var(--color-primary); }
 
 .managedPostgres {
   position: relative;
@@ -57,45 +61,30 @@
 
 .cloudProvider {
   flex: 1 1 calc(20% - 40px);
-  max-width: 120px;
+  max-width: 160px;
   text-align: center;
   margin: 10px;
-  opacity: 0;
-  animation: fadeIn 0.3s ease-in-out;
-  animation-fill-mode: forwards;
+  background: rgba(162, 153, 153, 0.09);
+  border: 2px solid transparent;
+  border-radius: 24px;
+  padding: 24px 20px;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-/* Individual delays for each icon */
-.cloudProvider:nth-child(1) {
-  animation-delay: 1s;
+.cloudProvider:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.1);
+  border-color: var(--color-primary);
 }
 
-.cloudProvider:nth-child(2) {
-  animation-delay: 1.1s;
-}
-
-.cloudProvider:nth-child(3) {
-  animation-delay: 1.2s;
-}
-
-.cloudProvider:nth-child(4) {
-  animation-delay: 1.3s;
-}
-
-.cloudProvider:nth-child(5) {
-  animation-delay: 1.4s;
-}
-
-.cloudProvider:nth-child(6) {
-  animation-delay: 1.5s;
-}
 
 .cloudProvider img {
-  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+  transition: transform 0.25s ease;
 }
 
 .cloudProvider:hover img {
-  transform: scale(1.1);
+  transform: scale(1.05);
 }
 
 .cloudImage {

--- a/src/components/ComparisonSection/styles.module.css
+++ b/src/components/ComparisonSection/styles.module.css
@@ -1,0 +1,105 @@
+/* ─── Section ────────────────────────────────────────────────────── */
+.section {
+  margin: var(--section-pt) 110px var(--section-pb);
+}
+
+/* ─── Cards row ──────────────────────────────────────────────────── */
+.cardsRow {
+  row-gap: 24px;
+  margin-bottom: 60px;
+  align-items: stretch;
+  --bs-gutter-x: 30px;
+}
+
+/* ─── Base card ──────────────────────────────────────────────────── */
+.cardLight,
+.cardDark {
+  border-radius: 24px;
+  overflow: hidden;
+  padding: 60px;
+  height: 100%;
+}
+
+.cardLight {
+  background: rgba(162, 153, 153, 0.09);
+  border: 1.083px solid rgba(255, 255, 255, 0.04);
+}
+
+.cardDark {
+  background: linear-gradient(203.91deg, #000000 19.64%, #743001 135.33%);
+  border: 2px solid var(--color-primary);
+}
+
+/* ─── Card title ─────────────────────────────────────────────────── */
+.cardTitle {
+  font-family: var(--font-base);
+  font-size: 36px;
+  font-weight: var(--fw-black);
+  margin: 0 0 40px;
+  line-height: 1.15;
+}
+
+.cardTitleLight { color: var(--color-black); }
+.cardTitleDark  { color: var(--color-white); }
+.orange         { color: var(--color-primary); }
+
+/* ─── Feature list ───────────────────────────────────────────────── */
+.featureList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.featureItem {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+}
+
+.featureItemDark { color: var(--color-white); }
+
+.checkIcon { flex-shrink: 0; }
+
+/* ─── Result row (animates last) ─────────────────────────────────── */
+.resultRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 80px;
+  opacity: 0; /* GSAP takes over */
+}
+
+.resultHeading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  margin: 0;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .section { margin: var(--section-pt) 80px var(--section-pb); }
+}
+
+@media (max-width: 900px) {
+  .section       { margin: var(--section-pt) 48px var(--section-pb); }
+  .cardTitle     { font-size: var(--fs-h3); }
+  .resultHeading { font-size: var(--fs-h3); }
+}
+
+@media (max-width: 768px) {
+  .section       { margin: var(--section-pt) 24px var(--section-pb); }
+  .cardLight,
+  .cardDark      { padding: 40px 28px; }
+  .resultRow     { flex-direction: column; gap: 24px; }
+  .resultHeading { white-space: normal; }
+}

--- a/src/components/ContactSection/index.js
+++ b/src/components/ContactSection/index.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+function TelegramIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+      <path
+        d="M20.6667 12.8888L14.4444 19.111L23.7778 28.4443L30 3.55545L2 14.4443L8.22222 17.5554L11.3333 26.8888L16 20.6666"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function YouTubeIcon() {
+  return (
+    <svg width="22" height="16" viewBox="0 0 22 16" fill="none" aria-hidden="true">
+      <rect width="22" height="16" rx="3.5" fill="#FF0000"/>
+      <path d="M9 11.5V4.5L15.5 8L9 11.5Z" fill="white"/>
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+      <path
+        d="M16 0C24.84 0 32 7.16 32 16C31.9991 19.3524 30.947 22.6201 28.9917 25.3432C27.0364 28.0664 24.2763 30.1077 21.1 31.18C20.3 31.34 20 30.84 20 30.42C20 29.88 20.02 28.16 20.02 26.02C20.02 24.52 19.52 23.56 18.94 23.06C22.5 22.66 26.24 21.3 26.24 15.16C26.24 13.4 25.62 11.98 24.6 10.86C24.76 10.46 25.32 8.82 24.44 6.62C24.44 6.62 23.1 6.18 20.04 8.26C18.76 7.9 17.4 7.72 16.04 7.72C14.68 7.72 13.32 7.9 12.04 8.26C8.98 6.2 7.64 6.62 7.64 6.62C6.76 8.82 7.32 10.46 7.48 10.86C6.46 11.98 5.84 13.42 5.84 15.16C5.84 21.28 9.56 22.66 13.12 23.06C12.66 23.46 12.24 24.16 12.1 25.2C11.18 25.62 8.88 26.3 7.44 23.88C7.14 23.4 6.24 22.22 4.98 22.24C3.64 22.26 4.44 23 5 23.3C5.68 23.68 6.46 25.1 6.64 25.56C6.96 26.46 8 28.18 12.02 27.44C12.02 28.78 12.04 30.04 12.04 30.42C12.04 30.84 11.74 31.32 10.94 31.18C7.75328 30.1193 4.98147 28.082 3.01778 25.3573C1.05409 22.6325 -0.00176096 19.3586 2.20462e-06 16C2.20462e-06 7.16 7.16 0 16 0Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+const columns = [
+  {
+    title: 'Contact',
+    subtitle: "We'd love to hear from you.",
+    links: [
+      { label: '@autobase_tech', href: 'https://x.com/autobase_tech', prefix: 'X' },
+      { label: 'info@autobase.tech', href: 'mailto:info@autobase.tech', prefix: '@' },
+      { label: '@autobase_tech', href: 'https://t.me/autobase_tech', prefix: <TelegramIcon /> },
+      { label: 'youtube.com/@Autobase', href: 'https://youtube.com/@Autobase', prefix: <YouTubeIcon /> },
+      { label: 'github.com/autobasehq', href: 'https://github.com/autobase-tech/autobase', prefix: <GitHubIcon /> },
+    ],
+  },
+  {
+    title: 'Docs',
+    subtitle: 'Everything you need to know.',
+    links: [
+      { label: '→ docs.autobase.tech', href: '/docs' },
+    ],
+  },
+  {
+    title: 'Support',
+    subtitle: 'Get help and resources.',
+    links: [
+      { label: '→ autobase.tech/support', href: '/support' },
+    ],
+  },
+];
+
+export default function ContactSection() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.grid}>
+          {columns.map((col) => (
+            <div key={col.title} className={styles.column}>
+              <h3 className={styles.columnTitle}>{col.title}</h3>
+              {col.subtitle && <p className={styles.columnSubtitle}>{col.subtitle}</p>}
+              <ul className={styles.linkList}>
+                {col.links.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className={styles.link}
+                      target={link.href.startsWith('http') ? '_blank' : undefined}
+                      rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                    >
+                      {link.prefix && <span className={styles.prefix}>{link.prefix}</span>}
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ContactSection/styles.module.css
+++ b/src/components/ContactSection/styles.module.css
@@ -1,0 +1,103 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.section {
+  background:
+    linear-gradient(to right, transparent 10%, var(--color-border) 10%, var(--color-border) 90%, transparent 90%) no-repeat 0 0 / 100% 1px,
+    var(--color-bg);
+  padding: 16px 0 var(--section-pb);
+  margin-top: 0;
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 80px;
+}
+
+/* ─── Grid ────────────────────────────────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 60px;
+}
+
+/* ─── Column ──────────────────────────────────────────────────────── */
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.columnTitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.columnSubtitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  margin: -8px 0 0;
+  line-height: 1.5;
+}
+
+/* ─── Link list ───────────────────────────────────────────────────── */
+.linkList {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.link:hover {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.prefix {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: var(--fw-bold);
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; }
+  .grid { grid-template-columns: 1fr 1fr; gap: 32px; }
+}
+
+@media (max-width: 600px) {
+  .inner { padding: 0 20px; }
+  .grid { grid-template-columns: 1fr; gap: 28px; }
+  .section { padding: 32px 0 var(--section-pb); }
+}
+
+@media (max-width: 480px) {
+  .linkList { gap: 18px; }
+  .prefix { min-width: 30px; height: 30px; }
+}

--- a/src/components/ExplainSection/styles.module.css
+++ b/src/components/ExplainSection/styles.module.css
@@ -1,0 +1,123 @@
+/* ─── Section card ───────────────────────────────────────────────── */
+.section {
+  position: relative;
+  z-index: 0;
+  /* 15% wider than WhatIsAutobase (110px margins) → max(4px, 126.5px - 7.5vw) */
+  margin: -5rem max(4px, calc(126.5px - 7.5vw)) 0;
+  border-radius: 48px;
+  background: rgba(162, 153, 153, 0.09);
+  overflow: hidden;
+}
+
+/* ─── Decorative orange inner border ────────────────────────────── */
+.innerBorder {
+  position: absolute;
+  inset: 20px 20px 22px 20px;
+  border: 1px solid var(--color-primary);
+  border-radius: 44px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ─── Inner content ──────────────────────────────────────────────── */
+.inner {
+  position: relative;
+  z-index: 1;
+  padding: 140px 100px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+/* ─── Title block — centered ─────────────────────────────────────── */
+.titleBlock {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* type.h2.900 */
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  margin: 0;
+  line-height: 1.1;
+}
+
+/* type.body-lg.500 */
+.subtext {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+}
+
+.orange { color: var(--color-primary); }
+
+/* ─── Icon item ──────────────────────────────────────────────────── */
+.iconItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 0;
+}
+
+/* 96×96 clip container */
+.iconClip {
+  flex-shrink: 0;
+  width: 96px;
+  height: 96px;
+  position: relative;
+  overflow: hidden;
+}
+
+/* ─── Icon text ──────────────────────────────────────────────────── */
+.iconText {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* type.body.500 */
+.iconLine {
+  font-family: var(--font-base);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+/*
+ * 15% wider than WhatIsAutobaseSection at each breakpoint.
+ * Formula per breakpoint: max(4px, (WhatIsAutobase_margin - 0.075 * WhatIsAutobase_width))
+ * where WhatIsAutobase_width = 100vw - 2*WhatIsAutobase_margin
+ *   → simplified: max(4px, calc(1.15*margin - 0.075*100vw))  ... see below
+ *
+ * Default  (WhatIsAutobase margin 110px): max(4px, calc(126.5px - 7.5vw))
+ * ≤1440px  (WhatIsAutobase margin  80px): max(4px, calc(92px   - 7.5vw))
+ * ≤900px   (WhatIsAutobase margin  48px): max(4px, calc(55px   - 7.5vw))
+ * ≤768px   (WhatIsAutobase margin  24px): 4px
+ */
+@media (max-width: 1200px) {
+  .section { margin: -5rem max(4px, calc(92px - 7.5vw)) 0; }
+  .inner { padding: 140px 80px 80px; }
+}
+
+@media (max-width: 900px) {
+  .section { margin: -5rem max(4px, calc(55px - 7.5vw)) 0; }
+  .inner { padding: 120px 48px 60px; }
+  .heading { font-size: var(--fs-h3); }
+}
+
+@media (max-width: 768px) {
+  .section { margin: -5rem 4px 0; }
+  .inner { padding: 100px 24px 48px; }
+  .heading { font-size: var(--fs-h3); }
+  .iconItem { gap: 16px; }
+}

--- a/src/components/FeaturedSection/styles.module.css
+++ b/src/components/FeaturedSection/styles.module.css
@@ -1,0 +1,336 @@
+/* ─── Section card ───────────────────────────────────────────────── */
+.section {
+  margin: var(--section-pt) 110px var(--section-pb);
+  border-radius: 48px;
+  background: linear-gradient(245.7deg, rgba(203, 195, 192, 0.2) 6.79%, rgba(255, 87, 34, 0.2) 117.19%);
+  padding: 40px 80px 40px;
+}
+
+.orange { color: var(--color-primary); }
+
+/* ─── Title block ────────────────────────────────────────────────── */
+.titleBlock {
+  text-align: center;
+  margin-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* 36px, fw-black */
+.titleLine {
+  font-family: var(--font-base);
+  font-size: 36px;
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  margin: 0;
+}
+
+/* type.body-lg.500 */
+.subtitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+}
+
+/* ─── Stats row ──────────────────────────────────────────────────── */
+.statsRow {
+  margin-bottom: 8px;
+}
+
+.statItem {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 24px;
+}
+
+.statText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* scales with viewport — ~40px at 1440px reference */
+.statNumber {
+  font-family: var(--font-base);
+  font-size: 2.8vw;
+  font-weight: var(--fw-black);
+  color: var(--color-primary);
+  line-height: 1;
+}
+
+/* 18px, regular */
+.statLabel {
+  font-family: var(--font-base);
+  font-size: 18px;
+  font-weight: var(--fw-regular);
+  color: var(--color-black);
+}
+
+/* ─── Git clone chart ───────────────────────────────────────────── */
+.chartCard {
+  max-width: 860px;
+  margin: 28px auto 32px;
+  padding: 22px 24px 14px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 24px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
+}
+
+.chartHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 4px;
+}
+
+.chartEyebrow {
+  font-family: var(--font-base);
+  font-size: 14px;
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.45);
+  margin: 0 0 6px;
+}
+
+.chartTitle {
+  font-family: var(--font-base);
+  font-size: 32px;
+  font-weight: var(--fw-bold);
+  color: var(--color-black);
+  margin: 0;
+}
+
+.chartTotal {
+  font-family: var(--font-base);
+  font-size: 20px;
+  font-weight: var(--fw-semibold);
+  color: rgba(0, 0, 0, 0.7);
+  margin: 8px 0 0;
+  white-space: nowrap;
+}
+
+.chartFrame {
+  width: 100%;
+}
+
+.chartSvg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.chartGridLine {
+  stroke: rgba(0, 0, 0, 0.14);
+  stroke-width: 1;
+}
+
+.chartVerticalLine {
+  stroke: rgba(0, 0, 0, 0.08);
+  stroke-width: 1;
+}
+
+.chartAxisLabel {
+  font-family: var(--font-base);
+  font-size: 14px;
+  font-weight: var(--fw-medium);
+  fill: rgba(0, 0, 0, 0.55);
+}
+
+.chartArea {
+  fill: url(#featuredAreaFill);
+}
+
+.chartLine {
+  fill: none;
+  stroke: #34a853;
+  stroke-width: 5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chartHighlightGlow {
+  fill: rgba(52, 168, 83, 0.18);
+}
+
+.chartHighlightOuter {
+  fill: #ffffff;
+  stroke: #34a853;
+  stroke-width: 3;
+}
+
+.chartHighlightInner {
+  fill: #34a853;
+}
+
+.chartTooltipBox {
+  fill: #ffffff;
+  stroke: rgba(0, 0, 0, 0.08);
+  stroke-width: 1;
+}
+
+.chartTooltipDate {
+  font-family: var(--font-base);
+  font-size: 16px;
+  font-weight: var(--fw-bold);
+  fill: rgba(0, 0, 0, 0.75);
+}
+
+.chartTooltipDot {
+  fill: #34a853;
+}
+
+.chartTooltipLabel {
+  font-family: var(--font-base);
+  font-size: 16px;
+  font-weight: var(--fw-medium);
+  fill: rgba(0, 0, 0, 0.72);
+}
+
+.chartTooltipValue {
+  font-family: var(--font-base);
+  font-size: 20px;
+  font-weight: var(--fw-bold);
+  fill: var(--color-black);
+}
+
+/* ─── Featured in ────────────────────────────────────────────────── */
+.featuredBlock {
+  text-align: center;
+  max-width: 537px;
+  margin: 0 auto 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.featuredTitle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+}
+
+/* 32px, fw-semibold */
+.featuredIn {
+  font-family: var(--font-base);
+  font-size: 32px;
+  font-weight: var(--fw-semibold);
+  color: var(--color-black);
+}
+
+.featuredLogo {
+  width: 60px;
+  height: 49px;
+  object-fit: contain;
+  display: block;
+  flex-shrink: 0;
+}
+
+.featuredArticle {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* 16px, regular */
+.articleTitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: rgba(0, 0, 0, 0.7);
+  margin: 0;
+}
+
+.articleLink {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.articleLink:hover {
+  color: var(--color-primary);
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+/* ─── Bottom trust cards ─────────────────────────────────────────── */
+.cardsRow {
+  gap: 0;
+  row-gap: 16px;
+}
+
+.card {
+  background: rgba(250, 250, 250, 0.45);
+  border-radius: 24px;
+  padding: 20px;
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  overflow: hidden;
+  height: 100%;
+}
+
+.cardIcon {
+  flex-shrink: 0;
+  width: 46px;
+  height: 46px;
+  object-fit: contain;
+}
+
+.cardText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+/* 16px, medium */
+.cardTitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+}
+
+/* 16px, regular */
+.cardBody {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: rgba(0, 0, 0, 0.6);
+  margin: 0;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .section { margin: var(--section-pt) 80px var(--section-pb); padding: 40px 60px; }
+}
+
+@media (max-width: 900px) {
+  .section { margin: var(--section-pt) 48px var(--section-pb); padding: 40px 48px; }
+  .titleLine { font-size: var(--fs-h3); }
+  .chartTitle { font-size: 26px; }
+  .chartTotal { font-size: 18px; }
+}
+
+@media (max-width: 768px) {
+  .section { margin: var(--section-pt) 24px var(--section-pb); padding: 32px 24px; }
+  .cardsRow { flex-direction: column; }
+  .card { width: 100%; }
+  .statNumber { font-size: 5.5vw; }
+  .chartCard { margin: 20px auto 32px; padding: 18px 14px 10px; }
+  .chartHeader { flex-direction: column; gap: 10px; }
+  .chartTitle { font-size: 22px; }
+  .chartTotal { margin-top: 0; white-space: normal; }
+}

--- a/src/components/FeaturesGridSection/index.js
+++ b/src/components/FeaturesGridSection/index.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+const features = [
+  {
+    icon: (
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <rect x="3" y="3" width="26" height="26" rx="4" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M10 16l4 4 8-8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+    label: 'HA',
+    title: 'High Availability',
+    description: 'Automatic High Availability',
+  },
+  {
+    icon: (
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <rect x="3" y="10" width="10" height="12" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+        <rect x="19" y="10" width="10" height="12" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M13 16h6M17 13l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+    label: 'Failover',
+    title: 'Failover',
+    description: 'Automatic Failover & Self-Healing',
+  },
+  {
+    icon: (
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <rect x="6" y="4" width="20" height="24" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+        <rect x="10" y="8" width="12" height="16" rx="1" stroke="currentColor" strokeWidth="1.5"/>
+        <line x1="13" y1="12" x2="19" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="13" y1="16" x2="19" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+    label: 'Backups',
+    title: 'Backups',
+    description: 'Continuous Backups',
+  },
+  {
+    icon: (
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <line x1="4" y1="16" x2="28" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="8" y1="10" x2="8" y2="22" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="14" y1="10" x2="14" y2="22" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="20" y1="10" x2="20" y2="22" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <circle cx="24" cy="16" r="3" fill="currentColor"/>
+      </svg>
+    ),
+    label: 'PITR',
+    title: 'PITR',
+    description: 'Point-in-Time Recovery',
+  },
+  {
+    icon: (
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <polyline points="4,22 10,14 15,18 20,10 28,10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        <line x1="4" y1="26" x2="28" y2="26" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+    label: 'Monitoring',
+    title: 'Monitoring',
+    description: 'Built-in Metrics & Alerting',
+  },
+  {
+    icon: (
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <path d="M16 4v18M10 16l6-12 6 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        <line x1="8" y1="26" x2="24" y2="26" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+    label: 'Upgrades',
+    title: 'Upgrades',
+    description: 'Zero-Downtime Upgrades',
+  },
+];
+
+export default function FeaturesGridSection() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.grid}>
+          {features.map((f) => (
+            <div key={f.label} className={styles.card}>
+              <div className={styles.icon}>{f.icon}</div>
+              <div className={styles.label}>{f.label}</div>
+              <div className={styles.description}>{f.description}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/FeaturesGridSection/styles.module.css
+++ b/src/components/FeaturesGridSection/styles.module.css
@@ -1,0 +1,93 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.section {
+  background:
+    linear-gradient(to right, transparent 10%, var(--color-border) 10%, var(--color-border) 90%, transparent 90%) no-repeat 0 0 / 100% 1px,
+    var(--color-bg);
+  padding: var(--section-pt) 0 var(--section-pb);
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 200px;
+}
+
+/* ─── Grid ────────────────────────────────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* ─── Card ────────────────────────────────────────────────────────── */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 32px 24px;
+  border-right: 1px solid var(--color-border);
+  transition: background 0.2s ease;
+}
+
+.card:last-child {
+  border-right: none;
+}
+
+.card:hover {
+  background: var(--color-surface);
+}
+
+/* ─── Icon ────────────────────────────────────────────────────────── */
+.icon {
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+}
+
+/* ─── Label ───────────────────────────────────────────────────────── */
+.label {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  color: var(--color-text);
+}
+
+/* ─── Description ─────────────────────────────────────────────────── */
+.description {
+  font-family: var(--font-base);
+  font-size: 13px;
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .inner { padding: 0 80px; }
+}
+
+@media (max-width: 1100px) {
+  .inner { padding: 0 48px; }
+  .grid { grid-template-columns: repeat(3, 1fr); }
+  .card:nth-child(3) { border-right: none; }
+  .card:nth-child(n+4) { border-top: 1px solid var(--color-border); }
+}
+
+@media (max-width: 768px) {
+  .inner { padding: 0 20px; }
+  .grid { grid-template-columns: repeat(2, 1fr); }
+  .card:nth-child(3) { border-right: 1px solid var(--color-border); }
+  .card:nth-child(2n) { border-right: none; }
+  .card:nth-child(n+3) { border-top: 1px solid var(--color-border); }
+}
+
+@media (max-width: 480px) {
+  .inner { padding: 0 16px; }
+  .grid { grid-template-columns: 1fr; }
+  .card { border-right: none; border-top: none; border-bottom: 1px solid var(--color-border); }
+  .card:last-child { border-bottom: none; }
+  .card:nth-child(n) { border-right: none; border-top: none; }
+}

--- a/src/components/HeroSection/index.js
+++ b/src/components/HeroSection/index.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import styles from './styles.module.css';
+
+const LINE1   = 'POSTGRESQL';
+const LINE2   = 'CONTROL PLANE';
+const SUBTEXT = 'Self-Hosted DBaaS';
+const SPEED   = 68; // ms per character
+const H1_TOTAL = LINE1.length + LINE2.length; // 23 chars → ~1.56s
+const SUB_DELAY = H1_TOTAL * SPEED + 200;     // starts after headline + 0.2s pause
+
+export default function HeroSection() {
+  const [h1Count,     setH1Count]     = useState(0);
+  const [subCount,    setSubCount]    = useState(0);
+  const [subStarted,  setSubStarted]  = useState(false);
+
+  // headline typing (left → right)
+  useEffect(() => {
+    if (h1Count >= H1_TOTAL) return;
+    const id = setTimeout(() => setH1Count(n => n + 1), SPEED);
+    return () => clearTimeout(id);
+  }, [h1Count]);
+
+  // subheading delay trigger
+  useEffect(() => {
+    const id = setTimeout(() => setSubStarted(true), SUB_DELAY);
+    return () => clearTimeout(id);
+  }, []);
+
+  // subheading typing (right → left: rightmost chars appear first)
+  useEffect(() => {
+    if (!subStarted || subCount >= SUBTEXT.length) return;
+    const id = setTimeout(() => setSubCount(n => n + 1), SPEED);
+    return () => clearTimeout(id);
+  }, [subStarted, subCount]);
+
+  const c1      = Math.min(h1Count, LINE1.length);
+  const c2      = Math.max(0, h1Count - LINE1.length);
+  const onLine1 = h1Count < LINE1.length;
+
+  // reverse: slice from the right, so last chars appear first
+  const subDisplayed = SUBTEXT.slice(SUBTEXT.length - subCount);
+  const subDone = subCount >= SUBTEXT.length;
+
+  return (
+    <section className={styles.hero}>
+      <div className={styles.inner}>
+        <h1 className={styles.heading}>
+          <span className={styles.line}>
+            {LINE1.slice(0, c1)}
+            {onLine1 && <span className={styles.cursor}>_</span>}
+          </span>
+          <span className={styles.line}>
+            {LINE2.slice(0, c2)}
+            {!onLine1 && <span className={styles.cursor}>_</span>}
+          </span>
+        </h1>
+
+        <p className={styles.subheading}>
+          {subStarted && (
+            <>
+              {subDisplayed}
+              {!subDone && <span className={styles.cursor}>_</span>}
+            </>
+          )}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/HeroSection/styles.module.css
+++ b/src/components/HeroSection/styles.module.css
@@ -1,0 +1,66 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.hero {
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.inner {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 80px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ─── Heading — Quantico Bold ─────────────────────────────────────── */
+.heading {
+  font-family: 'Quantico', sans-serif;
+  font-size: clamp(36px, 5vw, 64px);
+  font-weight: 700;
+  line-height: 1.05;
+  color: var(--color-text);
+  letter-spacing: -1px;
+  margin: 0;
+}
+
+.line {
+  display: block;
+  min-height: 1.05em;
+}
+
+/* ─── Terminal cursor ─────────────────────────────────────────────── */
+.cursor {
+  display: inline-block;
+  color: var(--color-text);
+  animation: blink 1s step-end infinite;
+  user-select: none;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ─── Subheading ──────────────────────────────────────────────────── */
+.subheading {
+  font-family: var(--font-base);
+  font-size: clamp(20px, 2.5vw, 24px);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .inner { padding: 48px 48px 32px; }
+}
+
+@media (max-width: 768px) {
+  .inner { padding: 40px 28px 28px; }
+}
+
+@media (max-width: 480px) {
+  .inner { padding: 32px 20px 24px; }
+}

--- a/src/components/HowItWorksSection/styles.module.css
+++ b/src/components/HowItWorksSection/styles.module.css
@@ -1,0 +1,241 @@
+/* ─── Section ────────────────────────────────────────────────────── */
+.section {
+  margin: 0 110px;
+  padding: var(--section-pt) 0 var(--section-pb);
+}
+
+/* ─── "How it works" heading ─────────────────────────────────────── */
+/* type.h2.900 */
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  margin: 0 0 40px;
+}
+
+/* ─── HIW row ────────────────────────────────────────────────────── */
+.hiwRow {
+  margin-bottom: 60px;
+}
+
+/* ─── Tabs ───────────────────────────────────────────────────────── */
+.tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+}
+
+.tab {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border: none;
+  border-radius: 23px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  background: rgba(250, 250, 250, 0.45);
+  box-shadow: inset -3.64px -3.64px 19.517px 0 rgba(179, 179, 179, 0.5);
+  transition: background 0.2s ease;
+}
+
+.tabActive {
+  background: var(--color-primary);
+}
+
+/* type.h3.600 */
+.tabTitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-semibold);
+  color: var(--color-black);
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+
+.tabActive .tabTitle {
+  color: var(--color-white);
+}
+
+/* type.caption.400 */
+.tabBody {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: rgba(0, 0, 0, 0.7);
+  line-height: 1.5;
+  transition: color 0.2s ease;
+}
+
+.tabActive .tabBody {
+  color: var(--color-white);
+}
+
+/* ─── Video placeholder ──────────────────────────────────────────── */
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-primary);
+  border-radius: 22px;
+  aspect-ratio: 788 / 488;
+  background: rgba(0, 0, 0, 0.03);
+  overflow: hidden;
+}
+
+.demoPreview {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/*
+.playIcon {
+  width: 64px;
+  height: 64px;
+  opacity: 0.6;
+}
+
+.placeholderLabel {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: rgba(0, 0, 0, 0.4);
+}
+*/
+
+/* ─── Comparing card ─────────────────────────────────────────────── */
+.comparing {
+  border-radius: 48px;
+  background: var(--bg-gradient-extra1);
+  box-shadow: 0 4px 2px rgba(0, 0, 0, 0.25);
+  padding: 40px 80px 60px;
+  color: var(--color-white);
+}
+
+.comparingHeader {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 40px;
+}
+
+/* type.h3.900 — 36px in design */
+.comparingTitle {
+  font-family: var(--font-base);
+  font-size: 36px;
+  font-weight: var(--fw-black);
+  color: var(--color-white);
+  margin: 0;
+}
+
+/* type.body-lg.500 */
+.comparingSubtitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+  margin: 0;
+}
+
+.orange { color: var(--color-primary); }
+
+/* ─── Comparison table ───────────────────────────────────────────── */
+.table {
+  display: flex;
+  flex-direction: column;
+}
+
+.tableRow {
+  display: flex;
+  align-items: center;
+  padding: 20px 0;
+}
+
+.tableHeaderRow {
+  padding-bottom: 8px;
+}
+
+.labelCell {
+  flex: 0 0 160px;
+  font-family: var(--font-base);
+  font-size: 18px;
+  font-weight: var(--fw-semibold);
+  color: var(--color-white);
+}
+
+.dataCell {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.headerCell {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-semibold);
+  color: var(--color-white);
+}
+
+.divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.15);
+  margin: 0;
+}
+
+/* ─── Bottom text ────────────────────────────────────────────────── */
+.bottomRow {
+  margin-top: 60px;
+}
+
+/* type.h2.900 */
+.bottomHeading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  line-height: 1.1;
+  margin: 0;
+}
+
+/* type.body.500 */
+.bottomBody {
+  font-family: var(--font-base);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .section { margin: 0 80px; }
+  .comparing { padding: 40px 60px 60px; }
+}
+
+@media (max-width: 900px) {
+  .section { margin: 0 48px; }
+  .heading { font-size: var(--fs-h3); }
+  .comparing { padding: 40px 40px 48px; }
+  .labelCell { flex: 0 0 100px; }
+  .comparingTitle { font-size: var(--fs-h3); }
+  .comparingSubtitle { font-size: var(--fs-body); }
+  .headerCell { font-size: var(--fs-body); }
+  .bottomHeading { font-size: var(--fs-h3); }
+}
+
+@media (max-width: 768px) {
+  .section { margin: 0 24px; }
+  .comparing { padding: 32px 24px 40px; }
+  .labelCell { flex: 0 0 80px; font-size: var(--fs-sm); }
+  .headerCell { font-size: var(--fs-sm); }
+  .hiwRow { margin-bottom: 40px; }
+}

--- a/src/components/PricingSection/index.js
+++ b/src/components/PricingSection/index.js
@@ -1,0 +1,189 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+const plans = [
+  {
+    id: 'free',
+    name: 'Free',
+    image: '/img/pricing/header-free.png',
+    description: 'Open-source version with limited platform functionality.',
+    features: [
+      'MIT License',
+      'Unlimited clusters',
+      'No guarantees & support'
+    ],
+    cta: 'Try Free',
+    href: 'https://github.com/autobase-tech/autobase',
+  },
+  {
+    id: 'standard',
+    name: 'Standard',
+    image: '/img/pricing/header-standard.png',
+    price: 256,
+    billing: 'per month if billed monthly.',
+    features: [
+      'Commercial license',
+      'Up to 2 clusters',
+      '1 DBA hour included',
+      'SLA: up to 24 hours (5×8)',
+    ],
+    cta: 'Start now',
+    href: '/docs',
+  },
+  {
+    id: 'professional',
+    name: 'Professional',
+    image: '/img/pricing/header-professional.png',
+    price: 1024,
+    billing: 'per month if billed monthly.',
+    popular: true,
+    features: [
+      'Commercial license',
+      'Up to 10 clusters',
+      'Up to 5 DBA hours included',
+      'Database Monitoring (health checks)',
+      'SLA: up to 8 hours (5×8)',
+    ],
+    cta: 'Launch production',
+    href: '/docs',
+  },
+  {
+    id: 'premium',
+    name: 'Premium',
+    image: '/img/pricing/header-premium.png',
+    price: 4096,
+    billing: 'per month if billed monthly.',
+    premium: true,
+    features: [
+      'Commercial license',
+      'Unlimited clusters',
+      'Up to 15 DBA hours included',
+      'Performance optimization',
+      'Database Management (upon request)',
+      'SLA: up to 1 hour (7×24)',
+    ],
+    cta: 'Scale with Autobase',
+    href: '/docs',
+  },
+];
+
+export default function PricingSection() {
+  const [monthly, setMonthly] = useState(true);
+  const getDisplayedPrice = (price) => (monthly ? price : price * 11);
+  const getBillingLabel = () =>
+    monthly ? 'per month if billed monthly.' : 'per year if billed yearly.';
+
+  return (
+    <section className={styles.section}>
+
+      {/* ── Heading ── */}
+      <div className={styles.hero}>
+        <h2 className={styles.heading}>Pricing</h2>
+        <p className={styles.subtitle}>
+          You are not buying a tool. You are buying a{' '}
+          <span className={styles.orange}>system</span>.
+        </p>
+      </div>
+
+      {/* ── Billing switcher (placeholder) ── */}
+      <div className={styles.switcherWrap}>
+        <p className={styles.billingLabel}>Billing period</p>
+        <div className={styles.switcher}>
+          <button
+            className={clsx(styles.switchBtn, !monthly && styles.switchBtnActive)}
+            onClick={() => setMonthly(false)}
+          >
+            Paid yearly
+          </button>
+          <button
+            className={clsx(styles.switchBtn, monthly && styles.switchBtnActive)}
+            onClick={() => setMonthly(true)}
+          >
+            Paid monthly
+          </button>
+        </div>
+      </div>
+
+      {/* ── Cards ── */}
+      <div className={clsx('row', styles.cardsRow)}>
+        {plans.map((plan) => (
+          <div key={plan.id} className="col-12 col-md-6 col-lg-3">
+            <div className={clsx(styles.card, plan.premium && styles.cardPremium)}>
+
+              {/* Header image */}
+              <div className={styles.cardHeader}>
+                <img
+                  src={plan.image}
+                  alt={plan.name}
+                  className={styles.cardImg}
+                />
+                {plan.popular && (
+                  <div className={styles.popularBadge}>Most popular</div>
+                )}
+              </div>
+
+              {/* Body */}
+              <div className={styles.cardBody}>
+                <p className={styles.planName}>{plan.name}</p>
+
+                <div className={styles.priceBlock}>
+                  {plan.price ? (
+                    <>
+                      <p className={styles.price}>
+                        <span className={styles.currency}>$</span>
+                        {getDisplayedPrice(plan.price)}
+                      </p>
+                      <p className={styles.billing}>{getBillingLabel()}</p>
+                    </>
+                  ) : (
+                    <p className={styles.freeDesc}>{plan.description}</p>
+                  )}
+                </div>
+
+                <ul className={styles.featureList}>
+                  {plan.features.map((f) => (
+                    <li key={f} className={styles.featureItem}>
+                      <img
+                        src="/img/pricing/icon-check.svg"
+                        alt=""
+                        aria-hidden="true"
+                        width={18}
+                        height={18}
+                        className={styles.checkIcon}
+                      />
+                      <span>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className={styles.ctaWrap}>
+                  <a href={plan.href} className={styles.cta} target="_blank" rel="noreferrer">
+                    {plan.cta}
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Notes ── */}
+      <div className={styles.notes}>
+        <div className={styles.noteItem}>
+          <img src="/img/pricing/icon-info.svg" alt="" aria-hidden="true" width={24} height={24} />
+          <span>1 month free with annual billing</span>
+        </div>
+        <div className={styles.noteItem}>
+          <img src="/img/pricing/icon-info.svg" alt="" aria-hidden="true" width={24} height={24} />
+          <span>additional DBA hours: $300/hour</span>
+        </div>
+        <div className={styles.noteItem}>
+          <img src="/img/pricing/stripe-logo.png" alt="Stripe" className={styles.stripeLogo} />
+          <span>All-in-one Payment management</span>
+        </div>
+      </div>
+
+    </section>
+  );
+}

--- a/src/components/PricingSection/styles.module.css
+++ b/src/components/PricingSection/styles.module.css
@@ -1,0 +1,294 @@
+/* ─── Section ────────────────────────────────────────────────────── */
+.section {
+  padding: var(--section-pt) 110px var(--section-pb);
+}
+
+/* ─── Hero block ─────────────────────────────────────────────────── */
+.hero {
+  text-align: center;
+  margin-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  margin: 0;
+}
+
+.subtitle {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+}
+
+.orange { color: var(--color-primary); }
+
+/* ─── Billing switcher ───────────────────────────────────────────── */
+.switcherWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 48px;
+}
+
+.billingLabel {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: rgba(0, 0, 0, 0.6);
+  margin: 0;
+}
+
+.switcher {
+  display: flex;
+  gap: 6px;
+  padding: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.7);
+  border-radius: 140px;
+}
+
+.switchBtn {
+  height: 44px;
+  padding: 0 24px;
+  border: none;
+  border-radius: 100px;
+  background: transparent;
+  font-family: var(--font-base);
+  font-size: 18px;
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.switchBtnActive {
+  background: var(--color-primary);
+  color: var(--color-white);
+}
+
+/* ─── Cards row ──────────────────────────────────────────────────── */
+.cardsRow {
+  row-gap: 24px;
+  margin-bottom: 48px;
+  align-items: stretch;
+}
+
+/* ─── Card ───────────────────────────────────────────────────────── */
+.card {
+  display: flex;
+  flex-direction: column;
+  background: rgba(162, 153, 153, 0.09);
+  border: 2px solid transparent;
+  border-radius: 24px;
+  overflow: hidden;
+  min-height: 728px;
+  height: 100%;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.1);
+  border-color: var(--color-primary);
+}
+
+.cardPremium {
+  border-color: var(--color-primary);
+  background: radial-gradient(
+    ellipse 130% 90% at 30% 130%,
+    rgba(200, 188, 204, 0.3),
+    rgba(255, 255, 255, 0.04)
+  );
+}
+
+/* ─── Card header ────────────────────────────────────────────────── */
+.cardHeader {
+  flex-shrink: 0;
+  height: 202px;
+  overflow: hidden;
+  position: relative;
+}
+
+.cardImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center center;
+  pointer-events: none;
+  display: block;
+}
+
+.popularBadge {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-primary);
+  color: var(--color-white);
+  font-family: var(--font-base);
+  font-size: 16px;
+  font-weight: var(--fw-medium);
+  padding: 6px 24px 10px;
+  border-radius: 0 0 12px 12px;
+  white-space: nowrap;
+}
+
+/* ─── Card body ──────────────────────────────────────────────────── */
+.cardBody {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 30px 30px;
+  gap: 20px;
+}
+
+/* 32px plan name */
+.planName {
+  font-family: var(--font-base);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-semibold);
+  color: var(--color-black);
+  margin: 0;
+}
+
+/* ─── Price block ────────────────────────────────────────────────── */
+.priceBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 60px;
+}
+
+.price {
+  font-family: var(--font-base);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-regular);
+  color: var(--color-primary);
+  margin: 0;
+  line-height: 1;
+}
+
+.currency {
+  color: var(--color-primary);
+}
+
+.billing {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: rgba(0, 0, 0, 0.6);
+  margin: 0;
+}
+
+.freeDesc {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: rgba(0, 0, 0, 0.6);
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* ─── Feature list ───────────────────────────────────────────────── */
+.featureList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex: 1;
+}
+
+.featureItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+}
+
+.checkIcon {
+  flex-shrink: 0;
+}
+
+/* ─── CTA ────────────────────────────────────────────────────────── */
+.ctaWrap {
+  margin-top: auto;
+  padding-top: 16px;
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 54px;
+  background: var(--color-primary);
+  color: var(--color-white) !important;
+  font-family: var(--font-base);
+  font-size: 18px;
+  font-weight: var(--fw-bold);
+  border-radius: 6px;
+  text-decoration: none !important;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.cta:hover {
+  opacity: 0.88;
+  transform: translateY(-1px);
+}
+
+/* ─── Notes row ──────────────────────────────────────────────────── */
+.notes {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 60px;
+  flex-wrap: wrap;
+}
+
+.noteItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  white-space: nowrap;
+}
+
+.stripeLogo {
+  height: 28px;
+  width: auto;
+  object-fit: contain;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .section { padding: var(--section-pt) 80px var(--section-pb); }
+}
+
+@media (max-width: 992px) {
+  .section { padding: var(--section-pt) 48px var(--section-pb); }
+  .notes { gap: 32px; }
+}
+
+@media (max-width: 768px) {
+  .section { padding: var(--section-pt) 24px var(--section-pb); }
+  .heading { font-size: var(--fs-h3); }
+  .subtitle { font-size: var(--fs-body); }
+  .notes { gap: 20px; flex-direction: column; align-items: center; }
+}

--- a/src/components/ProblemSection/styles.module.css
+++ b/src/components/ProblemSection/styles.module.css
@@ -1,0 +1,145 @@
+/* ─── Wrapper: vertical room for the image that bleeds above ──────── */
+.wrapper {
+  padding-top: 149px;
+  padding-bottom: var(--section-pb);
+}
+
+/* ─── Section card: overflow visible so image can escape top ─────── */
+.section {
+  position: relative;
+  overflow: visible;
+  border-radius: 48px;
+  margin: 0 110px;
+  aspect-ratio: 1312 / 480;
+}
+
+/* ─── ::before fills the card shape with the gradient ────────────── */
+.section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 48px;
+  background: var(--bg-gradient-extra1);
+  box-shadow: 0px 4px 2px rgba(0, 0, 0, 0.25);
+  z-index: 0;
+}
+
+/* ─── Awareness image — bleeds above card via negative top ──────── */
+.awarenessImage {
+  position: absolute;
+  top: -149px;
+  right: 0;
+  width: 50%;
+  height: auto;
+  object-fit: contain;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ─── Inner content sits above ::before ──────────────────────────── */
+.inner {
+  position: relative;
+  z-index: 1;
+  padding: 80px 90px;
+}
+
+/* ─── Heading — type.h3.900 ──────────────────────────────────────── */
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-black);
+  line-height: 1.2;
+  margin: 0 0 24px;
+}
+
+/* ─── Subtext — type.body-lg.500 ────────────────────────────────── */
+.subtext {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+  margin: 0 0 40px;
+}
+
+/* ─── List ───────────────────────────────────────────────────────── */
+.list {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.listItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  width: max-content;
+}
+
+.listIcon {
+  flex-shrink: 0;
+  width: 96px;
+  height: 96px;
+}
+
+/* ─── List text — type.btn.700 ──────────────────────────────────── */
+.listText {
+  font-family: var(--font-base);
+  font-size: var(--fs-btn);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+}
+
+/* ─── Bottom bar ─────────────────────────────────────────────────── */
+.bottomRow {
+  margin-top: 100px;
+}
+
+/* type.extra.900 = h2 size */
+.bottomHeading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  line-height: 1;
+  margin: 0;
+}
+
+/* type.body.500 */
+.bottomBody {
+  font-family: var(--font-base);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+  margin: 0;
+}
+
+/* ─── Colour helpers ─────────────────────────────────────────────── */
+.white  { color: var(--color-white); }
+.orange { color: var(--color-primary-alt); }
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .section { margin: 0 80px; }
+  .inner { padding: 80px 80px; }
+}
+
+@media (max-width: 900px) {
+  .section { margin: 0 48px; aspect-ratio: unset; }
+  .awarenessImage { width: 48%; }
+  .inner { padding: 60px 48px; }
+  .listIcon { width: 64px; height: 64px; }
+}
+
+@media (max-width: 768px) {
+  .wrapper { padding-top: 0; }
+  .section { margin: 0 24px; aspect-ratio: unset; }
+  .awarenessImage { display: none; }
+  .inner { padding: 48px 24px; }
+  .list { flex-direction: column; gap: 20px; }
+  .listItem { flex-direction: row; align-items: center; width: auto; }
+  .listIcon { width: 48px; height: 48px; }
+  .bottomRow { margin-top: 48px; }
+  .bottomHeading { font-size: var(--fs-h3); }
+}

--- a/src/components/ProductHighlightsSection/index.js
+++ b/src/components/ProductHighlightsSection/index.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+const highlights = [
+  {
+    icon: (
+      <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <circle cx="20" cy="20" r="17" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M13 20l4.5 4.5 9.5-9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+    title: 'Open Source',
+    description: 'MIT License',
+  },
+  {
+    icon: (
+      <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <path d="M20 6l-14 8v10c0 7.18 5.97 13.9 14 15.47C28.03 37.9 34 31.18 34 24V14L20 6z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+        <rect x="15" y="18" width="10" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M17 18v-3a3 3 0 016 0v3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+    title: 'Self-Hosted',
+    description: 'Full control. No vendor lock-in.',
+  },
+  {
+    icon: (
+      <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <polygon points="20,4 24,14 35,14 26,21 29,32 20,26 11,32 14,21 5,14 16,14" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinejoin="round"/>
+      </svg>
+    ),
+    title: 'Production Ready',
+    description: 'Battle-tested. For reliability.',
+  },
+];
+
+export default function ProductHighlightsSection() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.row}>
+          {highlights.map((h, i) => (
+            <React.Fragment key={h.title}>
+              <div className={styles.item}>
+                <div className={styles.icon}>{h.icon}</div>
+                <div className={styles.text}>
+                  <div className={styles.title}>{h.title}</div>
+                  <div className={styles.description}>{h.description}</div>
+                </div>
+              </div>
+              {i < highlights.length - 1 && <div className={styles.divider} />}
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProductHighlightsSection/styles.module.css
+++ b/src/components/ProductHighlightsSection/styles.module.css
@@ -1,0 +1,86 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.section {
+  background:
+    linear-gradient(to right, transparent 10%, var(--color-border) 10%, var(--color-border) 90%, transparent 90%) no-repeat 0 0 / 100% 1px,
+    linear-gradient(to right, transparent 10%, var(--color-border) 10%, var(--color-border) 90%, transparent 90%) no-repeat 0 100% / 100% 1px,
+    var(--color-bg);
+  padding: var(--section-pt) 0 var(--section-pb);
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 80px;
+}
+
+/* ─── Row ─────────────────────────────────────────────────────────── */
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+}
+
+/* ─── Item ────────────────────────────────────────────────────────── */
+.item {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex: 1;
+  justify-content: center;
+  padding: 0 40px;
+}
+
+/* ─── Icon ────────────────────────────────────────────────────────── */
+.icon {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+/* ─── Text ────────────────────────────────────────────────────────── */
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-bold);
+  line-height: 1.1;
+  color: var(--color-text);
+}
+
+.description {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+}
+
+/* ─── Divider ─────────────────────────────────────────────────────── */
+.divider {
+  width: 1px;
+  height: 60px;
+  background: var(--color-border);
+  flex-shrink: 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; }
+  .row { flex-direction: column; gap: 28px; }
+  .divider { width: 48px; height: 1px; }
+  .item { padding: 0; justify-content: flex-start; }
+}
+
+@media (max-width: 600px) {
+  .inner { padding: 0 20px; }
+  .item { gap: 16px; }
+  .icon svg { width: 32px; height: 32px; }
+}
+
+@media (max-width: 480px) {
+  .inner { padding: 0 16px; }
+}

--- a/src/components/SideNavbar/index.js
+++ b/src/components/SideNavbar/index.js
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from 'react';
+import Link from '@docusaurus/Link';
+import styles from './styles.module.css';
+
+function DocsIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <rect x="3" y="1.5" width="14" height="17" rx="2" stroke="currentColor" strokeWidth="1.4"/>
+      <path d="M6.5 6.5h7M6.5 10h7M6.5 13.5h4.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+    </svg>
+  );
+}
+
+export default function SideNavbar() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Show side nav after top navbar (72px) has fully left the viewport
+    const THRESHOLD = 80;
+    let ticking = false;
+
+    const onScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          setVisible(window.scrollY > THRESHOLD);
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <aside
+      className={`${styles.sidebar} ${visible ? styles.visible : ''}`}
+      aria-label="Side navigation"
+    >
+      {/* Logo */}
+      <Link to="/" className={styles.logoLink} aria-label="Autobase home">
+        <img
+          src="/img/navbar/logo-icon.svg"
+          alt="Autobase"
+          width={26}
+          height={23}
+          className={styles.logoImg}
+        />
+      </Link>
+
+      <div className={styles.divider} />
+
+      {/* Docs */}
+      <Link to="/docs" className={styles.iconLink} title="Docs">
+        <DocsIcon />
+      </Link>
+
+      <div className={styles.divider} />
+
+      {/* GitHub */}
+      <a
+        href="https://github.com/autobase-tech/autobase"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.iconLink}
+        title="GitHub"
+      >
+        <GitHubIcon />
+      </a>
+
+      <div className={styles.divider} />
+
+      {/* Demo */}
+      <a
+        href="https://demo.autobase.tech"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.demoBtn}
+        title="Book a demo"
+      >
+        <span className={styles.demoBtnText}>DEMO</span>
+      </a>
+    </aside>
+  );
+}

--- a/src/components/SideNavbar/styles.module.css
+++ b/src/components/SideNavbar/styles.module.css
@@ -1,0 +1,114 @@
+/* ─── Sidebar shell ────────────────────────────────────────────────── */
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 64px;
+  z-index: 190;
+  background: var(--color-bg);
+  border-right: 1px solid var(--color-border);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 28px 0;
+  gap: 20px;
+
+  /* Hidden by default — slides in from left */
+  transform: translateX(-100%);
+  opacity: 0;
+  transition:
+    transform 0.38s cubic-bezier(0.34, 1.46, 0.64, 1),
+    opacity   0.22s ease;
+
+}
+
+.visible {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+/* ─── Logo ─────────────────────────────────────────────────────────── */
+.logoLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  transition: opacity 0.15s ease;
+  text-decoration: none;
+}
+
+.logoLink:hover {
+  opacity: 0.72;
+  text-decoration: none;
+}
+
+.logoImg {
+  display: block;
+}
+
+/* ─── Divider ──────────────────────────────────────────────────────── */
+.divider {
+  width: 28px;
+  height: 1px;
+  background: var(--color-border);
+  flex-shrink: 0;
+}
+
+/* ─── Icon links ───────────────────────────────────────────────────── */
+.iconLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  color: hsl(0, 0%, 55%);
+  text-decoration: none;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.iconLink:hover {
+  color: var(--color-text);
+  background: var(--color-surface);
+  text-decoration: none;
+}
+
+/* ─── Demo button ──────────────────────────────────────────────────── */
+.demoBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 32px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.demoBtn:hover {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.demoBtn:hover .demoBtnText {
+  color: var(--color-primary);
+}
+
+.demoBtnText {
+  font-family: var(--font-base);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  color: hsl(0, 0%, 48%);
+  transition: color 0.15s ease;
+}
+
+/* ─── Mobile: never show ───────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .sidebar { display: none; }
+}

--- a/src/components/SocialProofSection/index.js
+++ b/src/components/SocialProofSection/index.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+function CalendarWithClockIcon() {
+  return (
+    <svg width="72" height="72" viewBox="0 0 72 72" fill="none" aria-hidden="true">
+      {/* Calendar body */}
+      <rect x="6" y="12" width="52" height="46" rx="4" stroke="#111" strokeWidth="2.2"/>
+      {/* Top bar */}
+      <rect x="6" y="12" width="52" height="14" rx="4" fill="#111" opacity="0.07"/>
+      <line x1="6" y1="26" x2="58" y2="26" stroke="#111" strokeWidth="2"/>
+      {/* Ring tabs */}
+      <line x1="20" y1="6" x2="20" y2="18" stroke="#111" strokeWidth="2.5" strokeLinecap="round"/>
+      <line x1="44" y1="6" x2="44" y2="18" stroke="#111" strokeWidth="2.5" strokeLinecap="round"/>
+      {/* Date dots — row 1 */}
+      <circle cx="20" cy="34" r="2.5" fill="#ccc"/>
+      <circle cx="32" cy="34" r="2.5" fill="#ccc"/>
+      <circle cx="44" cy="34" r="2.5" fill="#ccc"/>
+      {/* Date dots — row 2 */}
+      <circle cx="20" cy="43" r="2.5" fill="#ccc"/>
+      <circle cx="32" cy="43" r="2.5" fill="#ff5722"/>
+      <circle cx="44" cy="43" r="2.5" fill="#ccc"/>
+      {/* Date dots — row 3 */}
+      <circle cx="20" cy="52" r="2.5" fill="#ccc"/>
+      <circle cx="32" cy="52" r="2.5" fill="#ccc"/>
+
+      {/* Clock overlay — bottom right */}
+      <circle cx="52" cy="54" r="13" fill="white" stroke="#111" strokeWidth="2"/>
+      <line x1="52" y1="46" x2="52" y2="54" stroke="#111" strokeWidth="2" strokeLinecap="round"/>
+      <line x1="52" y1="54" x2="58" y2="58" stroke="#111" strokeWidth="2" strokeLinecap="round"/>
+      <circle cx="52" cy="54" r="2" fill="#111"/>
+    </svg>
+  );
+}
+
+function StopwatchIcon() {
+  return (
+    <svg width="72" height="72" viewBox="0 0 72 72" fill="none" aria-hidden="true">
+      {/* Speed lines */}
+      <line x1="4"  y1="34" x2="14" y2="34" stroke="#ff5722" strokeWidth="2.5" strokeLinecap="round"/>
+      <line x1="6"  y1="42" x2="16" y2="42" stroke="#ff5722" strokeWidth="2.5" strokeLinecap="round"/>
+      <line x1="4"  y1="50" x2="14" y2="50" stroke="#ff5722" strokeWidth="2.5" strokeLinecap="round"/>
+      {/* Top button */}
+      <rect x="30" y="4" width="12" height="6" rx="3" fill="#ff5722"/>
+      {/* Stopwatch circle */}
+      <circle cx="42" cy="44" r="25" stroke="#ff5722" strokeWidth="2.5"/>
+      {/* Side crown/button */}
+      <line x1="54" y1="22" x2="60" y2="16" stroke="#ff5722" strokeWidth="2.2" strokeLinecap="round"/>
+      <rect x="57" y="11" width="8" height="5" rx="2" fill="#ff5722"/>
+      {/* "10" text */}
+      <text
+        x="42" y="46"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="20"
+        fontWeight="800"
+        fill="#111"
+        fontFamily="system-ui, sans-serif"
+      >10</text>
+      {/* "MIN" text */}
+      <text
+        x="42" y="60"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="8"
+        fontWeight="700"
+        fill="#ff5722"
+        letterSpacing="1"
+        fontFamily="system-ui, sans-serif"
+      >MIN</text>
+    </svg>
+  );
+}
+
+export default function SocialProofSection() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.banner}>
+
+          {/* Left — text */}
+          <div className={styles.text}>
+            <p className={styles.before}>1 Month of Infrastructure Work</p>
+            <p className={styles.after}>10 Minutes in Autobase</p>
+            <span className={styles.underbar} />
+          </div>
+
+          {/* Right — visual */}
+          <div className={styles.visual}>
+
+            <div className={styles.timeBlock}>
+              <CalendarWithClockIcon />
+              <span className={styles.timeLabel}>1 MONTH</span>
+            </div>
+
+            {/* Arrow */}
+            <svg className={styles.arrow} width="48" height="24" viewBox="0 0 48 24" fill="none" aria-hidden="true">
+              <line x1="0" y1="12" x2="40" y2="12" stroke="#ff5722" strokeWidth="2.5" strokeLinecap="round"/>
+              <polyline points="30,4 42,12 30,20" fill="none" stroke="#ff5722" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+
+            <div className={styles.divider} />
+
+            <div className={styles.timeBlock}>
+              <StopwatchIcon />
+              <span className={`${styles.timeLabel} ${styles.accentLabel}`}>10 MINUTES</span>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/SocialProofSection/styles.module.css
+++ b/src/components/SocialProofSection/styles.module.css
@@ -1,0 +1,116 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.section {
+  background: var(--color-bg);
+  padding: 0 0 16px;
+  margin-bottom: 0;
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 80px;
+}
+
+/* ─── Banner card ─────────────────────────────────────────────────── */
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 60px;
+  padding: 40px 52px;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-bg);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 8px rgba(0, 0, 0, 0.04),
+    0 12px 24px rgba(0, 0, 0, 0.04),
+    0 24px 48px rgba(0, 0, 0, 0.03);
+}
+
+/* ─── Text block ──────────────────────────────────────────────────── */
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.before {
+  font-family: var(--font-base);
+  font-size: clamp(22px, 2.5vw, 30px);
+  font-weight: var(--fw-bold);
+  color: var(--color-text);
+  margin: 0;
+  line-height: 1.2;
+}
+
+.after {
+  font-family: var(--font-base);
+  font-size: clamp(22px, 2.5vw, 30px);
+  font-weight: var(--fw-black);
+  color: var(--color-primary);
+  margin: 0;
+  line-height: 1.2;
+}
+
+.underbar {
+  display: block;
+  width: 40px;
+  height: 3px;
+  background: var(--color-primary);
+  border-radius: 2px;
+  margin-top: 10px;
+}
+
+/* ─── Visual block ────────────────────────────────────────────────── */
+.visual {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  flex-shrink: 0;
+}
+
+.timeBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.timeLabel {
+  font-family: var(--font-base);
+  font-size: 12px;
+  font-weight: var(--fw-bold);
+  color: var(--color-text);
+  letter-spacing: 1.2px;
+}
+
+.accentLabel {
+  color: var(--color-primary);
+}
+
+.arrow {
+  flex-shrink: 0;
+}
+
+.divider {
+  width: 1px;
+  height: 80px;
+  background: var(--color-border);
+  flex-shrink: 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; }
+  .banner { flex-direction: column; gap: 32px; text-align: center; padding: 36px 40px; }
+  .underbar { margin: 10px auto 0; }
+}
+
+@media (max-width: 600px) {
+  .inner { padding: 0 20px; }
+  .banner { flex-direction: column; gap: 24px; padding: 28px 24px; }
+  .visual { gap: 16px; }
+  .divider { display: none; }
+  .before, .after { font-size: clamp(18px, 5vw, 24px); }
+}

--- a/src/components/ValuePropsSection/index.js
+++ b/src/components/ValuePropsSection/index.js
@@ -1,0 +1,85 @@
+import React, { useRef, useEffect } from 'react';
+import styles from './styles.module.css';
+
+const props = [
+  {
+    icon: (
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" aria-hidden="true">
+        <rect x="3" y="3" width="30" height="30" rx="3" stroke="currentColor" strokeWidth="1.5"/>
+        <text x="8" y="23" fontFamily="monospace" fontSize="14" fill="currentColor" fontWeight="bold">{'> _'}</text>
+      </svg>
+    ),
+    title: 'Your Infrastructure',
+    description: 'Run anywhere. You are in control.',
+  },
+  {
+    icon: (
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" aria-hidden="true">
+        <ellipse cx="18" cy="10" rx="12" ry="4.5" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M6 10v8c0 2.49 5.37 4.5 12 4.5s12-2.01 12-4.5v-8" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M6 18v8c0 2.49 5.37 4.5 12 4.5s12-2.01 12-4.5v-8" stroke="currentColor" strokeWidth="1.5"/>
+      </svg>
+    ),
+    title: 'Your Data',
+    description: 'Your data stays where you deploy.',
+  },
+  {
+    icon: (
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" aria-hidden="true">
+        <path d="M18 4L6 9v9c0 7.18 5.13 13.9 12 15.47C24.87 31.9 30 25.18 30 18V9L18 4z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+        <path d="M13 18l3.5 3.5 6.5-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+    title: 'Your Security',
+    description: 'Your network. Your rules.',
+  },
+];
+
+export default function ValuePropsSection() {
+  const gridRef = useRef(null);
+
+  useEffect(() => {
+    let ctx;
+    import('gsap').then(({ gsap }) =>
+      import('gsap/ScrollTrigger').then(({ ScrollTrigger }) => {
+        gsap.registerPlugin(ScrollTrigger);
+        ctx = gsap.context(() => {
+          gsap.fromTo(
+            gridRef.current?.querySelectorAll(`.${styles.card}`),
+            { opacity: 0, scale: 0.6, y: -10 },
+            {
+              opacity: 1,
+              scale: 1,
+              y: 0,
+              duration: 0.55,
+              ease: 'back.out(1.4)',
+              stagger: 0.12,
+              scrollTrigger: {
+                trigger: gridRef.current,
+                start: 'top 85%',
+                once: true,
+              },
+            }
+          );
+        });
+      })
+    );
+    return () => ctx?.revert();
+  }, []);
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.grid} ref={gridRef}>
+          {props.map((p) => (
+            <div key={p.title} className={styles.card}>
+              <div className={styles.icon}>{p.icon}</div>
+              <h3 className={styles.title}>{p.title}</h3>
+              <p className={styles.description}>{p.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ValuePropsSection/styles.module.css
+++ b/src/components/ValuePropsSection/styles.module.css
@@ -1,0 +1,86 @@
+/* ─── Section ─────────────────────────────────────────────────────── */
+.section {
+  background: var(--color-bg);
+  padding: var(--section-pt) 0 var(--section-pb);
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 80px;
+}
+
+/* ─── Grid ────────────────────────────────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+/* ─── Card ────────────────────────────────────────────────────────── */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 8px rgba(0, 0, 0, 0.03),
+    0 12px 24px rgba(0, 0, 0, 0.03),
+    0 24px 48px rgba(0, 0, 0, 0.02);
+  transition: box-shadow 0.2s ease;
+  opacity: 0;
+  will-change: transform, opacity;
+}
+
+.card:hover {
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.06),
+    0 6px 16px rgba(0, 0, 0, 0.06),
+    0 18px 36px rgba(0, 0, 0, 0.05),
+    0 32px 64px rgba(0, 0, 0, 0.04);
+}
+
+/* ─── Icon ────────────────────────────────────────────────────────── */
+.icon {
+  color: var(--color-text);
+}
+
+/* ─── Title ───────────────────────────────────────────────────────── */
+.title {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-bold);
+  line-height: 1.1;
+  color: var(--color-text);
+  margin: 0;
+}
+
+/* ─── Description ─────────────────────────────────────────────────── */
+.description {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; }
+  .grid { grid-template-columns: 1fr 1fr; gap: 16px; }
+}
+
+@media (max-width: 600px) {
+  .inner { padding: 0 20px; }
+  .grid { grid-template-columns: 1fr; gap: 12px; }
+  .card { padding: 24px 20px; gap: 12px; }
+}
+
+@media (max-width: 480px) {
+  .inner { padding: 0 16px; }
+}

--- a/src/components/VideoSection/styles.module.css
+++ b/src/components/VideoSection/styles.module.css
@@ -1,0 +1,127 @@
+/* ─── Section shell ───────────────────────────────────────────────── */
+.section {
+  background-color: var(--color-white);
+  color: var(--color-black);
+  padding: var(--section-pt) 0 var(--section-pb);
+}
+
+/* ─── Inner wrapper ───────────────────────────────────────────────── */
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 110px;
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+}
+
+/* ─── Heading — type.h2.900 ──────────────────────────────────────── */
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  line-height: 1.2;
+  color: var(--color-black);
+  text-align: center;
+  margin: 0 0 16px;
+}
+
+.orange {
+  color: var(--color-primary);
+}
+
+/* ─── Subtext — type.body-lg.500 ────────────────────────────────── */
+.subtext {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  text-align: center;
+  margin: 0;
+}
+
+/* ─── Icon item ───────────────────────────────────────────────────── */
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 29px;
+  width: 343px;
+  max-width: 100%;
+  margin: 0 auto;
+  text-align: center;
+}
+
+/* ─── Circle thumb — border-box so padding stays inside 92px ─────── */
+.thumb {
+  box-sizing: border-box;
+  width: 92px;
+  height: 92px;
+  border-radius: 70.933px;
+  border: 2px solid var(--color-primary-alt);
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  box-shadow:
+    inset 3.733px 3.733px 3.733px 0px var(--color-white),
+    inset -3.73px -3.73px 20px 0px rgba(179, 179, 179, 0.5);
+}
+
+.thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+/* ─── Label — type.body.500 ──────────────────────────────────────── */
+.label {
+  font-family: var(--font-base);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  text-align: center;
+  margin: 0;
+}
+
+/* ─── Video wrapper ───────────────────────────────────────────────── */
+.videoWrap {
+  display: flex;
+  justify-content: center;
+}
+
+/* ─── Fancy rounded card — 947×613 from Figma ────────────────────── */
+.videoCard {
+  width: 947px;
+  max-width: 100%;
+  aspect-ratio: 947 / 613;
+  border-radius: 48px;
+  overflow: hidden;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.16);
+}
+
+.videoCard iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .inner { padding: 0 80px; }
+}
+
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; gap: 40px; }
+  .item { width: auto; }
+  .videoCard { border-radius: 32px; }
+}
+
+@media (max-width: 768px) {
+  .inner { padding: 0 24px; gap: 32px; }
+  .heading { font-size: var(--fs-h3); }
+  .videoCard { width: 85%; border-radius: 24px; }
+}

--- a/src/components/WhatIsAutobaseSection/styles.module.css
+++ b/src/components/WhatIsAutobaseSection/styles.module.css
@@ -1,0 +1,140 @@
+/* ─── Card — same margin setup as ProblemSection ─────────────────── */
+.section {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  border-radius: 48px;
+  margin: var(--section-pt) 110px 0;
+  aspect-ratio: 1312 / 782;
+  background-color: #000000;
+
+  /*
+   * Two-layer background:
+   * 1. Black-to-transparent gradient (left 45%) — keeps text readable
+   * 2. The Figma image, right-anchored, filling the full card height
+   *
+   * The gradient covers the entire left column so text never sits
+   * directly on the vivid orange/glow portion of the image.
+   */
+  background-image:
+    linear-gradient(to right, #000000 35%, rgba(0, 0, 0, 0.6) 50%, transparent 70%),
+    url('/img/whatisautobase/bg.png');
+  background-position: right top, left 10vw top 0;
+  background-size: auto 100%, auto 100%;
+  background-repeat: no-repeat, no-repeat;
+
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+}
+
+/* ─── Inner — distributes content row and bottom bar ─────────────── */
+.inner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 80px 90px;
+  min-height: 0;
+}
+
+/* ─── Left column content ────────────────────────────────────────── */
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+}
+
+/* ─── Heading — type.h3.900 ──────────────────────────────────────── */
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-black);
+  color: var(--color-white);
+  margin: 0;
+}
+
+.orange { color: var(--color-primary); }
+.white  { color: var(--color-white); }
+
+/* ─── Subtext — type.body-lg.500 ────────────────────────────────── */
+.subtext {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+  max-width: 500px;
+  margin: 0;
+}
+
+/* ─── List ───────────────────────────────────────────────────────── */
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.listItem {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.listIcon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+}
+
+/* ─── List text — type.btn.500 / 18px ───────────────────────────── */
+.listText {
+  font-family: var(--font-base);
+  font-size: var(--fs-btn);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+}
+
+/* ─── Bottom bar ─────────────────────────────────────────────────── */
+.bottomRow {
+  margin-top: 40px;
+}
+
+/* type.h2.900 */
+.bottomHeading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  line-height: 1.1;
+  margin: 0;
+}
+
+/* type.body.500 */
+.bottomBody {
+  font-family: var(--font-base);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--color-white);
+  margin: 0;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .section { margin: var(--section-pt) 80px 0; }
+  .inner { padding: 80px 80px; }
+}
+
+@media (max-width: 900px) {
+  .section { margin: var(--section-pt) 48px 0; aspect-ratio: unset; }
+  .inner { padding: 60px 48px; }
+  .bottomHeading { font-size: var(--fs-h3); }
+}
+
+@media (max-width: 768px) {
+  .section { margin: var(--section-pt) 24px 0; }
+  .inner { padding: 48px 24px; }
+  .subtext { max-width: 100%; }
+  .bottomHeading { font-size: var(--fs-h3); }
+}

--- a/src/components/WhatYouGetSection/styles.module.css
+++ b/src/components/WhatYouGetSection/styles.module.css
@@ -1,0 +1,161 @@
+/* ─── Section shell — 100vh, flex column so CTA can sit at bottom ── */
+.section {
+  background-color: var(--color-white);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-top: var(--section-pt);
+}
+
+/* ─── Inner wrapper — fills section height, manages the two rows ──── */
+.inner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 110px;
+}
+
+/* ─── Row 1: content — expands to fill remaining vertical space ───── */
+.contentRow {
+  flex: 1;
+}
+
+/* ─── Left column image ───────────────────────────────────────────── */
+.mainImage {
+  width: 100%;
+  max-width: 726px;
+  height: auto;
+  object-fit: contain;
+  display: block;
+}
+
+/* ─── Right column content ────────────────────────────────────────── */
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+  align-items: flex-start;
+  text-align: left;
+  padding-left: 80px;
+}
+
+/* ─── Heading — type.h3.900 ──────────────────────────────────────── */
+.heading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  margin: 0;
+}
+
+.orange { color: var(--color-primary); }
+
+/* ─── Subtext — type.body-lg.500 ────────────────────────────────── */
+.subtext {
+  font-family: var(--font-base);
+  font-size: var(--fs-body-lg);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  margin: 0;
+}
+
+/* ─── List ───────────────────────────────────────────────────────── */
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: flex-start;
+}
+
+/* ─── List item — flex row, icon + text, right-to-left order ─────── */
+.listItem {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.listIcon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  order: -1;
+}
+
+/* ─── List text — type.btn / 18px medium ────────────────────────── */
+.listText {
+  font-family: var(--font-base);
+  font-size: var(--fs-btn);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+}
+
+/* ─── Row 2: CTA pinned at section bottom ────────────────────────── */
+.ctaRow {
+  padding: 60px 0;
+  text-align: center;
+}
+
+/* ─── CTA heading — type.h2.900 ─────────────────────────────────── */
+.ctaHeading {
+  font-family: var(--font-base);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-black);
+  color: var(--color-black);
+  text-align: center;
+  margin: 0 0 24px;
+}
+
+/* ─── CTA button — type.btn.700 ─────────────────────────────────── */
+.ctaButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+  height: 54px;
+  min-width: 242px;
+  padding: 0 24px;
+  background: var(--color-primary);
+  color: var(--color-white);
+  font-family: var(--font-base);
+  font-size: var(--fs-btn);
+  font-weight: var(--fw-bold);
+  border-radius: 6px;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.ctaButton:hover {
+  opacity: 0.88;
+  transform: translateY(-1px);
+  color: var(--color-white);
+  text-decoration: none;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 1200px) {
+  .inner { padding: 0 80px; }
+}
+
+@media (max-width: 900px) {
+  .inner { padding: 0 48px; }
+  .content { padding-left: 48px; }
+  .ctaHeading { font-size: var(--fs-h3); }
+}
+
+@media (max-width: 768px) {
+  .section { min-height: unset; }
+  .inner { padding: 0 24px; }
+  .content { padding-left: 0; }
+  .contentRow { flex: unset; padding: 48px 0 24px; }
+  .ctaRow { padding: 32px 0 48px; }
+  .ctaHeading { font-size: var(--fs-h3); }
+  .ctaButton { width: 100%; }
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,11 +1,16 @@
+@import url('https://fonts.googleapis.com/css2?family=Zalando+Sans+SemiExpanded:ital,wght@0,200..900;1,200..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Elms+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+@import 'bootstrap/dist/css/bootstrap-grid.min.css';
+
 /**
  * Any CSS included here will be global. The classic template
  * bundles Infima by default. Infima is a CSS framework designed to
  * work well for content-centric websites.
  */
 
-/* You can override the default Infima variables here. */
 :root {
+  /* ── Infima theme ───────────────────────────────────────────────── */
   --ifm-color-primary: #0366d6;
   --ifm-color-primary-dark: #024aaa;
   --ifm-color-primary-darker: #023e8a;
@@ -13,13 +18,69 @@
   --ifm-color-primary-light: #2b8cd8;
   --ifm-color-primary-lighter: #69b0e3;
   --ifm-color-primary-lightest: #a8d1ef;
+  --ifm-background-color: #ffffff;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-font-family-base: 'Quantico', sans-serif;
+
+  /* ── Font family ────────────────────────────────────────────────── */
+  --font-base: 'Quantico', sans-serif;
+
+  /* ── Font weights ───────────────────────────────────────────────── */
+  /* layer: type.*.200  */ --fw-light:    200;
+  /* layer: type.*.400  */ --fw-regular:  400;
+  /* layer: type.*.500  */ --fw-medium:   500;
+  /* layer: type.*.600  */ --fw-semibold: 600;
+  /* layer: type.*.700  */ --fw-bold:     700;
+  /* layer: type.*.900  */ --fw-black:    900;
+
+  /* ── Font sizes — ×1.2 scale, clamp() for fluid responsiveness ──── */
+  /* 72  → 86  */ --fs-hero:    clamp(48px, 6vw,   86px);
+  /* 48  → 58  */ --fs-h2:      clamp(32px, 4vw,   58px);
+  /* 32  → 38  */ --fs-h3:      clamp(22px, 2.8vw, 38px);
+  /* 27  → 33  */ --fs-navbar:  clamp(18px, 2.2vw, 33px);
+  /* 24  → 29  */ --fs-body-lg: clamp(18px, 2vw,   29px);
+  /* 20  → 24  */ --fs-body:    clamp(16px, 1.7vw, 24px);
+  /* 18  → 22  */ --fs-btn:     clamp(14px, 1.4vw, 22px);
+  /* 16  → 19  */ --fs-sm:      clamp(13px, 1.2vw, 19px);
+
+  /* ── Brand colours ──────────────────────────────────────────────── */
+  /* Figma var: COLOR-SECONDARY */ --color-primary:      #ff5722;
+                                   --color-primary-alt:  #fc6902;
+                                   --color-gradient-end: #be987d;
+                                   --color-white:        #ffffff;
+                                   --color-black:        #000000;
+                                   --color-muted:        #c7c7c7;
+
+  /* ── Light theme tokens ──────────────────────────────────────────── */
+  --color-bg:      #ffffff;
+  --color-bg-alt:  #f5f5f5;
+  --color-surface: #f9f9f9;
+  --color-text:    #111111;
+  --color-text-muted: #555555;
+  --color-border:  #e0e0e0;
+
+  /* ── Section vertical rhythm ─────────────────────────────────────── */
+  --section-pt: 72px;
+  --section-pb: 72px;
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
+@media (max-width: 900px) {
+  :root {
+    --section-pt: 52px;
+    --section-pb: 52px;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --section-pt: 40px;
+    --section-pb: 40px;
+  }
+}
+
 [data-theme='dark'] {
-  --ifm-background-color: #121212 !important;
+  --ifm-background-color: #ffffff !important;
   --ifm-color-primary: #58a6ff;
   --ifm-color-primary-dark: #3f8cfd;
   --ifm-color-primary-darker: #2a74d8;
@@ -30,48 +91,106 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
-/* Logo text styles */
-.navbar__title {
-  font-weight: 400;
-  font-size: 1.4rem;
-  line-height: 1.2;
-  white-space: nowrap;
-  font-family: 'Helvetica Neue', Arial, sans-serif;
+/* ─── Global typography ───────────────────────────────────────────── */
+body {
+  font-family: 'Quantico', sans-serif;
+  color: var(--color-text);
+  background-color: var(--color-bg) !important;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Quantico', sans-serif;
+  font-weight: 700;
+}
+
+p {
+  font-family: var(--font-base);
+  font-weight: var(--fw-light);
+}
+
+/* ─── Navbar — Light theme ────────────────────────────────────────── */
 .navbar {
-  padding-left: 4rem;
-  padding-right: 4rem;
+  background: var(--color-bg) !important;
+  border-bottom: 1px solid var(--color-border) !important;
+  box-shadow: none !important;
+}
+
+/* ─── Navbar hide-on-scroll transition ───────────────────────────── */
+.navbar--fixed-top {
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 0.3s ease !important;
+}
+
+.navbar--scrolled {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06) !important;
+}
+
+/* ─── Mobile navbar sidebar — glass effect ───────────────────────── */
+.navbar-sidebar {
+  background: rgba(255, 255, 255, 0.97) !important;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.08);
+}
+
+.navbar-sidebar__brand {
+  background: rgba(255, 255, 255, 0.95);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.navbar-sidebar__items .menu__link {
+  font-family: var(--font-base);
+  font-size: var(--fs-btn);
+  font-weight: var(--fw-medium);
+  color: var(--color-black);
+  border-radius: 8px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.navbar-sidebar__items .menu__link:hover {
+  background: rgba(255, 87, 34, 0.08);
+  color: var(--color-primary);
+}
+
+.navbar-sidebar__backdrop {
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+/* ─── Navbar brand/logo sizing ───────────────────────────────────── */
+.navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.navbar__logo {
+  height: 28px;
+  width: auto;
+}
+
+.navbar__title {
+  font-family: var(--font-base);
+  font-weight: var(--fw-bold);
+  font-size: 18px;
 }
 
 @media (max-width: 768px) {
-  .navbar {
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
+  .navbar__logo { height: 24px; }
+  .navbar__title { font-size: 16px; }
 }
 
-.navbar.navbar--transparent {
-  background: rgba(15, 15, 30, 0.15);
-  backdrop-filter: blur(18px) saturate(160%);
-  -webkit-backdrop-filter: blur(18px) saturate(160%);
-  box-shadow: none;
-  transition: background 0.3s ease, box-shadow 0.3s ease;
-}
-
-.navbar.navbar--transparent.navbar--scrolled {
-  background: rgba(15, 15, 30, 0.55);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
-}
-
-:root[data-theme='light'] .navbar.navbar--transparent {
-  background: rgba(255, 255, 255, 0.25);
-}
-
-:root[data-theme='light'] .navbar.navbar--transparent.navbar--scrolled {
-  background: rgba(255, 255, 255, 0.65);
-}
-
-.navbar.navbar--transparent :is(.navbar__item, .navbar__link, .navbar__brand) {
-  transition: color 0.2s ease;
+/* ─── Docs pages — light theme (orange accent) ────────────────────── */
+html.docs-doc-page {
+  --ifm-color-primary:          var(--color-primary);
+  --ifm-color-primary-dark:     var(--color-primary-alt);
+  --ifm-color-primary-darker:   #e04d1a;
+  --ifm-color-primary-darkest:  #c23c0e;
+  --ifm-color-primary-light:    #ff7043;
+  --ifm-color-primary-lighter:  #ff8a65;
+  --ifm-color-primary-lightest: #ffab91;
+  --ifm-link-color:             var(--color-primary);
+  --ifm-link-hover-color:       var(--color-primary-alt);
+  --ifm-tabs-color-active:      var(--color-primary);
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,171 +1,57 @@
-import React, { useEffect, useState } from 'react';
-import { useColorMode } from '@docusaurus/theme-common';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
+import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
-import CloudProviders from '@site/src/components/CloudProviders';
-import Features from '@site/src/components/Features';
-import Costs from '@site/src/components/Costs';
-import Sponsors from '@site/src/components/Sponsors';
-
-import Heading from '@theme/Heading';
-import styles from './index.module.css';
-
-function SectionWithBackground({ children }) {
-  const { colorMode } = useColorMode();
-  const [currentMode, setCurrentMode] = useState(null);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-
-  useEffect(() => {
-    setCurrentMode(colorMode);
-  }, [colorMode]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) {
-      return undefined;
-    }
-
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
-
-    updatePreference();
-    mediaQuery.addEventListener('change', updatePreference);
-
-    return () => mediaQuery.removeEventListener('change', updatePreference);
-  }, []);
-
-  if (currentMode === null) {
-    return null;
-  }
-
-  const overlayOpacity = currentMode === 'dark' ? 0.6 : 0.5; // Dynamic transparency based on theme
-
-  return (
-    <div style={{ position: 'relative', padding: '40px 0', overflow: 'hidden' }}>
-      {prefersReducedMotion ? (
-        <div
-          aria-hidden="true"
-          style={{
-            position: 'absolute',
-            inset: 0,
-            zIndex: 0,
-            background: 'linear-gradient(135deg, #0f172a 0%, #1d3557 45%, #0b3d91 100%)',
-          }}
-        />
-      ) : (
-        <video
-          src="/img/background.mp4"
-          autoPlay
-          loop
-          muted
-          playsInline
-          preload="metadata"
-          aria-hidden="true"
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-            zIndex: 0,
-          }}
-        />
-      )}
-      <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
-      <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          backgroundColor: `rgba(0, 0, 0, ${overlayOpacity})`,
-          zIndex: 1,
-        }}
-      />
-    </div>
-  );
-}
-
-function HomepageHeader() {
-  return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <Heading as="h1" style={{ fontSize: '2.6rem', fontWeight: '600' }} className={styles.gradientText}>
-          Autobase for PostgreSQL® - Your own DBaaS
-        </Heading>
-        <Heading as="h2" style={{ fontSize: '1.6rem', fontWeight: '500', marginBottom: '20px' }} className={styles.heroBanner_description}>
-          Run your own managed Postgres platform
-        </Heading>
-        <Heading as="h3" style={{ fontSize: '1.2rem', fontWeight: '400', marginBottom: '20px', color: '#c7c7c7' }} className={styles.heroBanner_description}>
-          The control layer for data infrastructure, automating deployment and Day 2 operations, reducing cost and operational overhead — even without a dedicated DBA team.
-        </Heading>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="https://demo.autobase.tech">
-            Demo
-          </Link>
-          <Link
-            className="button button--primary button--lg"
-            style={{ marginLeft: '10px' }}
-            to="/docs">
-            Get Started
-          </Link>
-        </div>
-        <p style={{ textAlign: 'center', fontSize: '0.9rem', color: '#c7c7c7', marginTop: '10px' }}>
-          (use the token <strong>demo</strong> to access)
-        </p>
-      </div>
-    </header>
-  );
-}
-
-function DemoEmbed() {
-  return (
-    <div style={{ position: 'relative', boxSizing: 'content-box', maxHeight: '80vh', width: '100%', aspectRatio: '1.643835616438356', padding: '40px 0' }}>
-      <iframe
-        src="https://app.supademo.com/embed/cm17ui80e035n13s2q3lkg5he?embed_v=2"
-        title="Autobase Console (UI) demo"
-        allow="clipboard-write"
-        frameBorder="0"
-        webkitallowfullscreen="true"
-        mozallowfullscreen="true"
-        allowFullScreen
-        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
-      ></iframe>
-    </div>
-  );
-}
+import HeroSection from '@site/src/components/HeroSection';
+import ArchDiagramSection from '@site/src/components/ArchDiagramSection';
+import ValuePropsSection from '@site/src/components/ValuePropsSection';
+import ProductHighlightsSection from '@site/src/components/ProductHighlightsSection';
+import CLISection from '@site/src/components/CLISection';
+import ContactSection from '@site/src/components/ContactSection';
+import SocialProofSection from '@site/src/components/SocialProofSection';
 
 export default function Home() {
+  // GSAP scroll reveal — blur + fade from below, fires once per section
   useEffect(() => {
-    const nav = document.querySelector('.navbar');
-    if (!nav) return;
-    nav.classList.add('navbar--transparent');
-    const onScroll = () => {
-      if (window.scrollY > 40) nav.classList.add('navbar--scrolled');
-      else nav.classList.remove('navbar--scrolled');
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-      nav.classList.remove('navbar--transparent');
-      nav.classList.remove('navbar--scrolled');
-    };
+    let ctx;
+    Promise.all([import('gsap'), import('gsap/ScrollTrigger')]).then(
+      ([{ gsap }, { ScrollTrigger }]) => {
+        gsap.registerPlugin(ScrollTrigger);
+        ctx = gsap.context(() => {
+          document.querySelectorAll('main section').forEach((section) => {
+            gsap.fromTo(
+              section,
+              { y: 32, opacity: 0, filter: 'blur(6px)' },
+              {
+                y: 0,
+                opacity: 1,
+                filter: 'blur(0px)',
+                duration: 0.85,
+                ease: 'expo.out',
+                scrollTrigger: {
+                  trigger: section,
+                  start: 'top 90%',
+                  once: true,
+                },
+              }
+            );
+          });
+        });
+      }
+    );
+    return () => ctx?.revert();
   }, []);
+
   return (
     <Layout
       title="autobase"
       description="Automated database platform for PostgreSQL">
-      <SectionWithBackground>
-        <HomepageHeader />
-      </SectionWithBackground>
+      <HeroSection />
       <main>
-        <CloudProviders />
-        <DemoEmbed />
-        <Features />
-        <Costs />
-        <Sponsors />
+        <ArchDiagramSection />
+        <ValuePropsSection />
+        <ProductHighlightsSection />
+        <CLISection />
+        <ContactSection />
+        <SocialProofSection />
       </main>
     </Layout>
   );

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -67,7 +67,7 @@
 }
 
 /* Adaptive style for mobile devices */
-@media (max-width: 1440px) {
+@media (max-width: 1200px) {
   .heroBanner_description,
   .heroLead,
   .heroBenefits {

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.inner}>
+
+        <div className={styles.divider} />
+
+        <div className={styles.logoMark}>
+          <img src="/img/footer/logo-icon.svg" alt="" aria-hidden="true" width={40} height={35} />
+          <span className={styles.logoText}>Autobase</span>
+        </div>
+
+        <p className={styles.copyright}>
+          Copyright © 2019 - 2026. All rights reserved.
+        </p>
+
+        <p className={styles.legal}>
+          Payments are processed by NovaBridge Tech OÜ,<br />
+          which acts as the authorized payment and billing partner for Autobase.
+        </p>
+
+        <p className={styles.legal}>
+          NovaBridge Tech OÜ. Reg. nr 17390133 · Võru tn 11,<br />
+          Lasnamäe linnaosa, Tallinn 13612, Harjumaa, Estonia
+        </p>
+
+      </div>
+    </footer>
+  );
+}

--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -1,0 +1,70 @@
+/* ─── Footer ──────────────────────────────────────────────────────── */
+.footer {
+  background: var(--color-bg);
+}
+
+.divider {
+  width: 80%;
+  height: 1px;
+  background: var(--color-border);
+  margin: 0 auto;
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 80px 56px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ─── Logo ────────────────────────────────────────────────────────── */
+.logoMark {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.logoText {
+  font-family: var(--font-base);
+  font-size: 20px;
+  font-weight: var(--fw-regular);
+  color: var(--color-text);
+  line-height: 1;
+}
+
+/* ─── Copyright ───────────────────────────────────────────────────── */
+.copyright {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text);
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* ─── Legal text ──────────────────────────────────────────────────── */
+.legal {
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  color: var(--color-text-muted);
+  margin: 0;
+  line-height: 1.7;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .inner { padding: 40px 48px 48px; }
+}
+
+@media (max-width: 600px) {
+  .inner { padding: 32px 20px 40px; }
+  .divider { width: 90%; }
+}
+
+@media (max-width: 480px) {
+  .inner { padding: 28px 16px 36px; }
+}

--- a/src/theme/Navbar/index.js
+++ b/src/theme/Navbar/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+const navLinks = [
+  { label: '/docs',   to: '/docs' },
+  { label: '/github', href: 'https://github.com/autobase-tech/autobase' },
+  { label: '/demo',   href: 'https://demo.autobase.tech' },
+];
+
+export default function Navbar() {
+  return (
+    <nav className={clsx('navbar', styles.navbar)}>
+      <div className={styles.inner}>
+
+        {/* Logo */}
+        <Link to="/" className={styles.logo} aria-label="autobase home">
+          <img
+            src="/img/navbar/logo-icon.svg"
+            alt=""
+            className={styles.logoIcon}
+            width={40}
+            height={35}
+          />
+          <span className={styles.logoText}>Autobase</span>
+        </Link>
+
+        {/* Center nav links */}
+        <nav className={styles.navLinks} aria-label="Main navigation">
+          {navLinks.map((link) =>
+            link.to ? (
+              <Link key={link.label} to={link.to} className={styles.navLink}>
+                {link.label}
+              </Link>
+            ) : (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.navLink}
+              >
+                {link.label}
+              </a>
+            )
+          )}
+        </nav>
+
+
+      </div>
+    </nav>
+  );
+}

--- a/src/theme/Navbar/styles.module.css
+++ b/src/theme/Navbar/styles.module.css
@@ -1,0 +1,167 @@
+/* ─── Navbar shell ────────────────────────────────────────────────── */
+.navbar {
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0;
+  height: auto;
+}
+
+/* ─── Inner container — matches hero padding ──────────────────────── */
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 80px;
+  height: 72px;
+  width: 100%;
+}
+
+/* ─── Logo ────────────────────────────────────────────────────────── */
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.logo:hover {
+  text-decoration: none;
+  opacity: 0.75;
+}
+
+.logoIcon { display: block; }
+
+.logoText {
+  font-family: var(--font-base);
+  font-size: 22px;
+  font-weight: var(--fw-regular);
+  color: var(--color-text);
+  white-space: nowrap;
+  line-height: 1;
+}
+
+/* ─── Right nav links ─────────────────────────────────────────────── */
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  margin-left: auto;
+}
+
+.navLink {
+  font-family: var(--font-base);
+  font-size: 15px;
+  font-weight: 400;
+  color: hsl(0, 0%, 52%);
+  text-decoration: none;
+  position: relative;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+
+.navLink::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 1px;
+  background: var(--color-text);
+  transition: width 0.25s ease;
+}
+
+.navLink:hover {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.navLink:hover::after {
+  width: 100%;
+}
+
+/* ─── Right actions ───────────────────────────────────────────────── */
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+}
+
+/* ─── CTA buttons (unchanged) ─────────────────────────────────────── */
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  padding: 0 20px;
+  border-radius: 6px;
+  font-family: var(--font-base);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.cta:hover {
+  text-decoration: none;
+  opacity: 0.85;
+  transform: translateY(-1px);
+}
+
+.ctaPrimary {
+  background: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+}
+
+.ctaPrimary:hover { color: var(--color-white); }
+
+.ctaSecondary {
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.ctaSecondary:hover { color: var(--color-text); border-color: #aaaaaa; }
+
+/* ─── Icon links ──────────────────────────────────────────────────── */
+.iconLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  opacity: 0.55;
+  transition: opacity 0.2s ease;
+}
+
+.iconLink:hover { opacity: 1; }
+
+.iconLink img { filter: brightness(0); }
+
+/* ─── Mobile ──────────────────────────────────────────────────────── */
+.mobileActions { display: none; }
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .inner { padding: 0 48px; }
+  .navLinks { gap: 20px; }
+}
+
+@media (max-width: 900px) {
+  .navLinks { display: none; }
+  .inner { padding: 0 32px; }
+}
+
+@media (max-width: 768px) {
+  .inner { padding: 0 24px; height: 60px; }
+  .actions { display: none; }
+  .mobileActions { display: flex; align-items: center; }
+  .mobileActions .cta { height: 40px; }
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { useLocation } from '@docusaurus/router';
+import ClickEffect from '@site/src/components/ClickEffect';
+import SideNavbar from '@site/src/components/SideNavbar';
+
+function SideNavbarGate() {
+  const { pathname } = useLocation();
+  if (pathname !== '/') return null;
+  return <SideNavbar />;
+}
+
+export default function Root({ children }) {
+  return (
+    <>
+      {children}
+      <BrowserOnly>{() => <ClickEffect />}</BrowserOnly>
+      <BrowserOnly>{() => <SideNavbarGate />}</BrowserOnly>
+    </>
+  );
+}


### PR DESCRIPTION
New landing page sections replacing old home page:
- HeroSection: Quantico typewriter heading + cursor animation
- ArchDiagramSection: architecture diagram with pinch-zoom lightbox portal
- ValuePropsSection: 3-column feature cards with GSAP stagger scroll-reveal
- ProductHighlightsSection: Open Source / Self-Hosted / Production Ready
- CLISection: inline terminal + fullscreen overlay with matrix canvas animation
- SocialProofSection: light card with time-to-deploy stats
- ContactSection: icon-prefixed links with column subtitles
- FeaturesGridSection: 6-column HA/Failover/Backups/PITR/Monitoring/Upgrades grid

Design system & layout:
- Custom CSS tokens (--color-*, --section-pt/pb, --fs-* clamp scale)
- Light theme Quantico font, GSAP scroll-reveal blur+fade on all sections
- Navbar: non-fixed on desktop, simplified link bar
- Footer: Autobase-branded with logo/copyright only (docs pages keep original)
- SideNavbar: slides in from left on home scroll (desktop only, hidden on mobile)
- Full mobile responsive pass: 2→1 column grids, tighter padding, 80% dividers
- PricingSection: includes Vitaliy's latest pricing updates